### PR TITLE
feat: Use custom HTTP Client, custom Logger, PHPStan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run test suite
         run: composer run-script test
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --ansi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,35 +3,37 @@ name: Test
 on:
   pull_request:
   push:
-    branches: [ "main" ]
-
-permissions:
-  contents: read
+    branches:
+      - main
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict
 
       - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-php-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $user = \AmplitudeExperiment\User::builder()
     ->userProperties(['premium' => True])
     ->build();
 
-$variants = $client->fetch($user)->wait();
+$variants = $client->fetch($user);
 
 // (3) Access a flag's variant
 $variant = $variants['FLAG_KEY'] ?? null;
@@ -49,7 +49,7 @@ $experiment = new \AmplitudeExperiment\Experiment();
 $client = $experiment->initializeLocal('<DEPLOYMENT_KEY>');
 
 // (2) Start the local evaluation client.
-$client->start()->wait();
+$client->start();
 
 // (3) Evaluate a user.
 $user = \AmplitudeExperiment\User::builder()

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ if ($variant) {
 $experiment = new \AmplitudeExperiment\Experiment();
 $client = $experiment->initializeLocal('<DEPLOYMENT_KEY>');
 
-// (2) Start the local evaluation client.
-$client->start();
+// (2) Fetch latest flag configurations for the local evaluation client.
+$client->refreshFlagConfigs();
 
 // (3) Evaluate a user.
 $user = \AmplitudeExperiment\User::builder()

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "^7.4 || ^8",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7",
-    "psr/log": "^1"
+    "psr/log": "^1 || ^2 || ^3"
   },
   "require-dev": {
     "phpunit/phpunit": "9.*",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
   "prefer-stable": true,
   "require": {
     "php": "^7.4 || ^8",
-    "lastguest/murmurhash": "^1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7",
     "psr/log": "^1"

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,14 @@
     "lastguest/murmurhash": "^1",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^7",
-    "monolog/monolog": "^2"
+    "psr/log": "^1"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.*"
+    "phpunit/phpunit": "9.*",
+    "phpstan/phpstan": "^1.0"
+  },
+  "suggest": {
+    "monolog/monolog": "Allows more advanced logging of the application flow"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "9.*",
-    "phpstan/phpstan": "^1.0"
+    "phpstan/phpstan": "^1"
   },
   "suggest": {
     "monolog/monolog": "Allows more advanced logging of the application flow"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7a1f41c427c192bbdacce9631e0746f",
+    "content-hash": "48eed85ab7c8388545faf2d591ce9d86",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -330,53 +330,6 @@
                 }
             ],
             "time": "2023-12-03T20:05:35+00:00"
-        },
-        {
-            "name": "lastguest/murmurhash",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lastguest/murmurhash-php.git",
-                "reference": "8eb06483456bc98f5adb7707d981a8ef6a065fa2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lastguest/murmurhash-php/zipball/8eb06483456bc98f5adb7707d981a8ef6a065fa2",
-                "reference": "8eb06483456bc98f5adb7707d981a8ef6a065fa2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=4.3"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "murmurhash3.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Stefano Azzolini",
-                    "email": "lastguest@gmail.com",
-                    "homepage": "https://github.com/lastguest/murmurhash-php"
-                }
-            ],
-            "description": "MurmurHash3 Hash",
-            "homepage": "https://github.com/lastguest/murmurhash-php",
-            "keywords": [
-                "hash",
-                "hashing",
-                "murmur"
-            ],
-            "support": {
-                "issues": "https://github.com/lastguest/murmurhash-php/issues",
-                "source": "https://github.com/lastguest/murmurhash-php/tree/master"
-            },
-            "time": "2016-05-16T23:22:58+00:00"
         },
         {
             "name": "psr/http-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48eed85ab7c8388545faf2d591ce9d86",
+    "content-hash": "a734945f7a1c1cc01371bb797325c3da",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1014,23 +1014,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1080,7 +1080,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -1088,7 +1088,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1677,20 +1677,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -1722,7 +1722,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1730,7 +1730,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2004,20 +2004,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -2049,7 +2049,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -2057,7 +2057,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b2a0888b709340519126b0c9db130b3",
+    "content-hash": "d7a1f41c427c192bbdacce9631e0746f",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.8.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
-                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104",
+                "reference": "41042bc7ab002487b876a0683fc8dce04ddce104",
                 "shasum": ""
             },
             "require": {
@@ -32,11 +32,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -114,7 +114,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.1"
             },
             "funding": [
                 {
@@ -130,28 +130,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-27T10:20:53+00:00"
+            "time": "2023-12-03T20:35:24+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
+                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
-                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/bbff78d96034045e58e13dedd6ad91b5d1253223",
+                "reference": "bbff78d96034045e58e13dedd6ad91b5d1253223",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "type": "library",
             "extra": {
@@ -197,7 +197,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.1"
+                "source": "https://github.com/guzzle/promises/tree/2.0.2"
             },
             "funding": [
                 {
@@ -213,20 +213,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T15:11:55+00:00"
+            "time": "2023-12-03T20:19:20+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
-                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221",
+                "reference": "45b30f99ac27b5ca93cb4831afe16285f57b8221",
                 "shasum": ""
             },
             "require": {
@@ -240,9 +240,9 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.1",
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+                "phpunit/phpunit": "^8.5.36 || ^9.6.15"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -313,7 +313,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.2"
             },
             "funding": [
                 {
@@ -329,7 +329,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-27T10:13:57+00:00"
+            "time": "2023-12-03T20:05:35+00:00"
         },
         {
             "name": "lastguest/murmurhash",
@@ -377,108 +377,6 @@
                 "source": "https://github.com/lastguest/murmurhash-php/tree/master"
             },
             "time": "2016-05-16T23:22:58+00:00"
-        },
-        {
-            "name": "monolog/monolog",
-            "version": "2.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
-                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
-                "doctrine/couchdb": "~1.0@dev",
-                "elasticsearch/elasticsearch": "^7 || ^8",
-                "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
-                "guzzlehttp/guzzle": "^7.4",
-                "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
-                "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^0.12.91",
-                "phpunit/phpunit": "^8.5.14",
-                "predis/predis": "^1.1 || ^2.0",
-                "rollbar/rollbar": "^1.3 || ^2 || ^3",
-                "ruflin/elastica": "^7",
-                "swiftmailer/swiftmailer": "^5.3|^6.0",
-                "symfony/mailer": "^5.4 || ^6",
-                "symfony/mime": "^5.4 || ^6"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
-                "ext-mbstring": "Allow to work properly with unicode symbols",
-                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
-                "ext-openssl": "Required to send log messages using SSL",
-                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "https://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "https://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "support": {
-                "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/Seldaek",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-10-27T15:25:26+00:00"
         },
         {
             "name": "psr/http-client",
@@ -934,16 +832,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.17.1",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
-                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -984,9 +882,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-08-13T19:53:39+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1098,6 +996,68 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.50",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-13T10:59:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1420,16 +1380,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -1503,7 +1463,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -1519,7 +1479,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2487,16 +2447,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2525,7 +2485,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2533,7 +2493,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a734945f7a1c1cc01371bb797325c3da",
+    "content-hash": "c42bcc95b8a3bba4f70533ad1f9b0be1",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -785,25 +785,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
+                "reference": "4a21235f7e56e713259a6f76bf4b5ea08502b9dc",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -811,7 +813,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -835,9 +837,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.0"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-01-07T17:17:35+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -952,16 +954,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.50",
+            "version": "1.10.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/27816a01aea996191ee14d010f325434c0ee76fa",
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa",
                 "shasum": ""
             },
             "require": {
@@ -1010,7 +1012,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T10:59:42+00:00"
+            "time": "2024-01-15T10:43:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1333,16 +1335,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -1416,7 +1418,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -1432,7 +1434,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,6 @@ parameters:
 		- src
 
 	excludePaths:
-		- src/Assignment/AssignmentConfigBuilder.php
 		- src/EvaluationCore
 
 	scanFiles:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+	level: 8
+	paths:
+		- src
+
+	excludePaths:
+		- src/Assignment/AssignmentConfigBuilder.php
+		- src/EvaluationCore
+
+	scanFiles:
+		- src/EvaluationCore/Util.php

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -2,8 +2,8 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
-use AmplitudeExperiment\Http\GuzzleFetchClient;
+use AmplitudeExperiment\Http\HttpClientInterface;
+use AmplitudeExperiment\Http\GuzzleHttpClient;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 
@@ -17,7 +17,7 @@ class Amplitude
      * @var array<array<string,mixed>>
      */
     protected array $queue = [];
-    protected FetchClientInterface $httpClient;
+    protected HttpClientInterface $httpClient;
     private LoggerInterface $logger;
     private AmplitudeConfig $config;
 
@@ -26,7 +26,7 @@ class Amplitude
         $this->apiKey = $apiKey;
         $this->logger = $logger;
         $this->config = $config ?? AmplitudeConfig::builder()->build();
-        $this->httpClient = $this->config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
+        $this->httpClient = $this->config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
     }
 
     public function flush(): void

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -26,7 +26,7 @@ class Amplitude
         $this->apiKey = $apiKey;
         $this->logger = $logger;
         $this->config = $config ?? AmplitudeConfig::builder()->build();
-        $this->httpClient = $this->config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
+        $this->httpClient = $this->config->httpClient ?? $this->config->httpClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
     }
 
     public function flush(): void
@@ -58,7 +58,7 @@ class Amplitude
      */
     private function post(string $url, array $payload): void
     {
-        $fetchClient = $this->httpClient->getClient();
+        $httpClient = $this->httpClient->getClient();
         $payloadJson = json_encode($payload);
         if ($payloadJson === false) {
             $this->logger->error('[Amplitude] Failed to encode payload: ' . json_last_error());
@@ -68,7 +68,7 @@ class Amplitude
             ->createRequest('POST', $url, $payloadJson)
             ->withHeader('Content-Type', 'application/json');
         try {
-            $response = $fetchClient->sendRequest($request);
+            $response = $httpClient->sendRequest($request);
             if ($response->getStatusCode() != 200) {
                 $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase());
                 return;

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -70,7 +70,6 @@ class Amplitude
         try {
             $response = $fetchClient->sendRequest($request);
             if ($response->getStatusCode() != 200) {
-                echo json_encode($payload) . "\n";
                 $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase());
                 return;
             }

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -64,16 +64,19 @@ class Amplitude
             $this->logger->error('[Amplitude] Failed to encode payload: ' . json_last_error());
             return;
         }
-        $request = $this->httpClient->createRequest('POST', $url)->withHeader('json', $payloadJson);
+        $request = $this->httpClient
+            ->createRequest('POST', $url, $payloadJson)
+            ->withHeader('Content-Type', 'application/json');
         try {
             $response = $fetchClient->sendRequest($request);
             if ($response->getStatusCode() != 200) {
+                echo json_encode($payload) . "\n";
                 $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase());
-            } else {
-                $this->logger->debug("[Amplitude] Event sent successfully: " . $payloadJson);
-                $this->queue = [];
+                return;
             }
             $this->logger->debug("[Amplitude] Event sent successfully: " . $payloadJson);
+            $this->queue = [];
+
         } catch (ClientExceptionInterface $e) {
             $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $e->getMessage());
         }

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -2,13 +2,10 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
-use AmplitudeExperiment\Backoff;
-use GuzzleHttp\Client;
-use GuzzleHttp\Promise\PromiseInterface;
-use Monolog\Logger;
-use function AmplitudeExperiment\initializeLogger;
-
-require_once __DIR__ . '/../Util.php';
+use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\GuzzleFetchClient;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Amplitude client for sending events to Amplitude.
@@ -17,40 +14,29 @@ class Amplitude
 {
     private string $apiKey;
     protected array $queue = [];
-    protected Client $httpClient;
-    private Logger $logger;
+    protected FetchClientInterface $httpClient;
+    private LoggerInterface $logger;
     private ?AmplitudeConfig $config;
 
-    public function __construct(string $apiKey, bool $debug, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, LoggerInterface $logger, AmplitudeConfig $config = null)
     {
         $this->apiKey = $apiKey;
-        $this->httpClient = new Client();
-        $this->logger = initializeLogger($debug);
+        $this->logger = $logger;
         $this->config = $config ?? AmplitudeConfig::builder()->build();
+        $this->httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
     }
 
-    public function flush(): PromiseInterface
+    public function flush()
     {
         $payload = ["api_key" => $this->apiKey, "events" => $this->queue, "options" => ["min_id_length" => $this->config->minIdLength]];
-
-        // Fetch initial flag configs and await the result.
-        return Backoff::doWithBackoff(
-            function () use ($payload) {
-                return $this->post($this->config->serverUrl, $payload)->then(
-                    function () {
-                        $this->queue = [];
-                    }
-                );
-            },
-            new Backoff($this->config->flushMaxRetries, 1, 1, 1)
-        );
+        $this->post($this->config->serverUrl, $payload);
     }
 
     public function logEvent(Event $event)
     {
         $this->queue[] = $event->toArray();
         if (count($this->queue) >= $this->config->flushQueueSize) {
-            $this->flush()->wait();
+            $this->flush();
         }
     }
 
@@ -60,27 +46,26 @@ class Amplitude
     public function __destruct()
     {
         if (count($this->queue) > 0) {
-            $this->flush()->wait();
+            $this->flush();
         }
     }
 
-    private function post(string $url, array $payload): PromiseInterface
+    private function post(string $url, array $payload)
     {
-        // Using sendAsync to make an asynchronous request
-        $promise = $this->httpClient->postAsync($url, [
-            'json' => $payload,
-        ]);
-
-        return $promise->then(
-            function ($response) use ($payload) {
-                // Process the successful response if needed
-                $this->logger->debug("[Amplitude] Event sent successfully: " . json_encode($payload));
-            },
-            function (\Exception $exception) use ($payload) {
-                // Handle the exception for async request
-                $this->logger->error('[Amplitude] Failed to send event: ' . json_encode($payload) . ', ' . $exception->getMessage());
-                throw $exception;
+        $fetchClient = $this->httpClient->getClient();
+        $payloadJson = json_encode($payload);
+        $request = $this->httpClient->createRequest('POST', $url)->withHeader('json', $payloadJson);
+        try {
+            $response = $fetchClient->sendRequest($request);
+            if ($response->getStatusCode() != 200) {
+                $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $response->getStatusCode() . ' ' . $response->getReasonPhrase());
+            } else {
+                $this->logger->debug("[Amplitude] Event sent successfully: " . $payloadJson);
+                $this->queue = [];
             }
-        );
+            $this->logger->debug("[Amplitude] Event sent successfully: " . $payloadJson);
+        } catch (ClientExceptionInterface $e) {
+            $this->logger->error('[Amplitude] Failed to send event: ' . $payloadJson . ', ' . $e->getMessage());
+        }
     }
 }

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -32,8 +32,11 @@ class AmplitudeConfig
     /**
      * True to use batch API endpoint, False to use HTTP V2 API endpoint.
      */
-    public string $useBatch;
+    public bool $useBatch;
     public ?FetchClientInterface $fetchClient;
+    /**
+     * @var array<string, mixed>
+     */
     public array $guzzleClientConfig;
 
     const DEFAULTS = [
@@ -56,6 +59,9 @@ class AmplitudeConfig
         'guzzleClientConfig' => []
     ];
 
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     */
     public function __construct(
         int    $flushQueueSize,
         int    $minIdLength,

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -2,6 +2,8 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+use AmplitudeExperiment\Http\FetchClientInterface;
+
 /**
  * Configuration options for Amplitude. This is an object that can be created using
  * a {@link AmplitudeConfigBuilder}. Example usage:
@@ -18,10 +20,6 @@ class AmplitudeConfig
     /**
      * The maximum retry attempts for an event when receiving error response.
      */
-    public int $flushMaxRetries;
-    /**
-     * The minimum length of user_id and device_id for events. Default to 5.
-     */
     public int $minIdLength;
     /**
      * The server zone of project. Default to 'US'. Support 'EU'.
@@ -35,6 +33,8 @@ class AmplitudeConfig
      * True to use batch API endpoint, False to use HTTP V2 API endpoint.
      */
     public string $useBatch;
+    public ?FetchClientInterface $fetchClient;
+    public array $guzzleClientConfig;
 
     const DEFAULTS = [
         'serverZone' => 'US',
@@ -52,23 +52,27 @@ class AmplitudeConfig
         'minIdLength' => 5,
         'flushQueueSize' => 200,
         'flushMaxRetries' => 12,
+        'fetchClient' => null,
+        'guzzleClientConfig' => []
     ];
 
     public function __construct(
         int    $flushQueueSize,
-        int    $flushMaxRetries,
         int    $minIdLength,
         string $serverZone,
         string $serverUrl,
-        bool   $useBatch
+        bool   $useBatch,
+        ?FetchClientInterface $fetchClient,
+        array  $guzzleClientConfig
     )
     {
         $this->flushQueueSize = $flushQueueSize;
-        $this->flushMaxRetries = $flushMaxRetries;
         $this->minIdLength = $minIdLength;
         $this->serverZone = $serverZone;
         $this->serverUrl = $serverUrl;
         $this->useBatch = $useBatch;
+        $this->fetchClient = $fetchClient;
+        $this->guzzleClientConfig = $guzzleClientConfig;
     }
 
     public static function builder(): AmplitudeConfigBuilder

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -36,7 +36,7 @@ class AmplitudeConfig
     /**
      * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?HttpClientInterface $fetchClient;
+    public ?HttpClientInterface $httpClient;
     /**
      * @var array<string, mixed>
      * The configuration for the underlying default {@link GuzzleHttpClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
@@ -59,7 +59,7 @@ class AmplitudeConfig
         'minIdLength' => 5,
         'flushQueueSize' => 200,
         'flushMaxRetries' => 12,
-        'fetchClient' => null,
+        'httpClient' => null,
         'guzzleClientConfig' => []
     ];
 
@@ -72,7 +72,7 @@ class AmplitudeConfig
         string               $serverZone,
         string               $serverUrl,
         bool                 $useBatch,
-        ?HttpClientInterface $fetchClient,
+        ?HttpClientInterface $httpClient,
         array                $guzzleClientConfig
     )
     {
@@ -81,7 +81,7 @@ class AmplitudeConfig
         $this->serverZone = $serverZone;
         $this->serverUrl = $serverUrl;
         $this->useBatch = $useBatch;
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         $this->guzzleClientConfig = $guzzleClientConfig;
     }
 

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -4,7 +4,7 @@ namespace AmplitudeExperiment\Amplitude;
 
 use AmplitudeExperiment\Assignment\AssignmentConfig;
 use AmplitudeExperiment\Assignment\AssignmentConfigBuilder;
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 
 /**
  * Configuration options for Amplitude. The Amplitude object is created when you create an {@link AssignmentConfig}.
@@ -34,12 +34,12 @@ class AmplitudeConfig
      */
     public bool $useBatch;
     /**
-     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?FetchClientInterface $fetchClient;
+    public ?HttpClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default {@link GuzzleFetchClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
+     * The configuration for the underlying default {@link GuzzleHttpClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 
@@ -67,13 +67,13 @@ class AmplitudeConfig
      * @param array<string, mixed> $guzzleClientConfig
      */
     public function __construct(
-        int    $flushQueueSize,
-        int    $minIdLength,
-        string $serverZone,
-        string $serverUrl,
-        bool   $useBatch,
-        ?FetchClientInterface $fetchClient,
-        array  $guzzleClientConfig
+        int                  $flushQueueSize,
+        int                  $minIdLength,
+        string               $serverZone,
+        string               $serverUrl,
+        bool                 $useBatch,
+        ?HttpClientInterface $fetchClient,
+        array                $guzzleClientConfig
     )
     {
         $this->flushQueueSize = $flushQueueSize;

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -2,13 +2,13 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+use AmplitudeExperiment\Assignment\AssignmentConfig;
+use AmplitudeExperiment\Assignment\AssignmentConfigBuilder;
 use AmplitudeExperiment\Http\FetchClientInterface;
 
 /**
- * Configuration options for Amplitude. This is an object that can be created using
- * a {@link AmplitudeConfigBuilder}. Example usage:
- *
- * AmplitudeConfigBuilder::builder()->serverZone("EU")->build();
+ * Configuration options for Amplitude. The Amplitude object is created when you create an {@link AssignmentConfig}.
+ * Options should be set using {@link AssignmentConfigBuilder}.
  */
 class AmplitudeConfig
 {
@@ -33,9 +33,13 @@ class AmplitudeConfig
      * True to use batch API endpoint, False to use HTTP V2 API endpoint.
      */
     public bool $useBatch;
+    /**
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
+     */
     public ?FetchClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
+     * The configuration for the underlying default {@link GuzzleFetchClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -12,6 +12,9 @@ class AmplitudeConfigBuilder
     protected ?string $serverUrl = null;
     protected bool $useBatch = AmplitudeConfig::DEFAULTS['useBatch'];
     protected ?FetchClientInterface $fetchClient = AmplitudeConfig::DEFAULTS['fetchClient'];
+    /**
+     * @var array<string, mixed>
+     */
     protected array $guzzleClientConfig = AmplitudeConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
@@ -54,13 +57,16 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     */
     public function guzzleClientConfig(array $guzzleClientConfig): AmplitudeConfigBuilder
     {
         $this->guzzleClientConfig = $guzzleClientConfig;
         return $this;
     }
 
-    public function build()
+    public function build(): AmplitudeConfig
     {
         if (!$this->serverUrl) {
             if ($this->useBatch) {

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -2,14 +2,17 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+use AmplitudeExperiment\Http\FetchClientInterface;
+
 class AmplitudeConfigBuilder
 {
     protected int $flushQueueSize = AmplitudeConfig::DEFAULTS['flushQueueSize'];
-    protected int $flushMaxRetries = AmplitudeConfig::DEFAULTS['flushMaxRetries'];
     protected int $minIdLength = AmplitudeConfig::DEFAULTS['minIdLength'];
     protected string $serverZone = AmplitudeConfig::DEFAULTS['serverZone'];
     protected ?string $serverUrl = null;
     protected bool $useBatch = AmplitudeConfig::DEFAULTS['useBatch'];
+    protected ?FetchClientInterface $fetchClient = AmplitudeConfig::DEFAULTS['fetchClient'];
+    protected array $guzzleClientConfig = AmplitudeConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
     {
@@ -18,12 +21,6 @@ class AmplitudeConfigBuilder
     public function flushQueueSize(int $flushQueueSize): AmplitudeConfigBuilder
     {
         $this->flushQueueSize = $flushQueueSize;
-        return $this;
-    }
-
-    public function flushMaxRetries(int $flushMaxRetries): AmplitudeConfigBuilder
-    {
-        $this->flushMaxRetries = $flushMaxRetries;
         return $this;
     }
 
@@ -51,6 +48,18 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
+    public function fetchClient(FetchClientInterface $fetchClient): AmplitudeConfigBuilder
+    {
+        $this->fetchClient = $fetchClient;
+        return $this;
+    }
+
+    public function guzzleClientConfig(array $guzzleClientConfig): AmplitudeConfigBuilder
+    {
+        $this->guzzleClientConfig = $guzzleClientConfig;
+        return $this;
+    }
+
     public function build()
     {
         if (!$this->serverUrl) {
@@ -62,11 +71,12 @@ class AmplitudeConfigBuilder
         }
         return new AmplitudeConfig(
             $this->flushQueueSize,
-            $this->flushMaxRetries,
             $this->minIdLength,
             $this->serverZone,
             $this->serverUrl,
-            $this->useBatch
+            $this->useBatch,
+            $this->fetchClient,
+            $this->guzzleClientConfig
         );
     }
 }

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -66,7 +66,10 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
-    public function build(): AmplitudeConfig
+    /**
+     * @phpstan-ignore-next-line
+     */
+    public function build()
     {
         if (!$this->serverUrl) {
             if ($this->useBatch) {

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -11,7 +11,7 @@ class AmplitudeConfigBuilder
     protected string $serverZone = AmplitudeConfig::DEFAULTS['serverZone'];
     protected ?string $serverUrl = null;
     protected bool $useBatch = AmplitudeConfig::DEFAULTS['useBatch'];
-    protected ?HttpClientInterface $fetchClient = AmplitudeConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $httpClient = AmplitudeConfig::DEFAULTS['httpClient'];
     /**
      * @var array<string, mixed>
      */
@@ -51,9 +51,9 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
-    public function fetchClient(HttpClientInterface $fetchClient): AmplitudeConfigBuilder
+    public function httpClient(HttpClientInterface $httpClient): AmplitudeConfigBuilder
     {
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         return $this;
     }
 
@@ -84,7 +84,7 @@ class AmplitudeConfigBuilder
             $this->serverZone,
             $this->serverUrl,
             $this->useBatch,
-            $this->fetchClient,
+            $this->httpClient,
             $this->guzzleClientConfig
         );
     }

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -2,7 +2,7 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 
 class AmplitudeConfigBuilder
 {
@@ -11,7 +11,7 @@ class AmplitudeConfigBuilder
     protected string $serverZone = AmplitudeConfig::DEFAULTS['serverZone'];
     protected ?string $serverUrl = null;
     protected bool $useBatch = AmplitudeConfig::DEFAULTS['useBatch'];
-    protected ?FetchClientInterface $fetchClient = AmplitudeConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $fetchClient = AmplitudeConfig::DEFAULTS['fetchClient'];
     /**
      * @var array<string, mixed>
      */
@@ -51,7 +51,7 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
-    public function fetchClient(FetchClientInterface $fetchClient): AmplitudeConfigBuilder
+    public function fetchClient(HttpClientInterface $fetchClient): AmplitudeConfigBuilder
     {
         $this->fetchClient = $fetchClient;
         return $this;

--- a/src/Amplitude/Event.php
+++ b/src/Amplitude/Event.php
@@ -5,7 +5,13 @@ namespace AmplitudeExperiment\Amplitude;
 class Event
 {
     public ?string $eventType = null;
+    /**
+     * @var ?array<mixed>
+     */
     public ?array $eventProperties = null;
+    /**
+     * @var ?array<mixed>
+     */
     public ?array $userProperties = null;
     public ?string $userId = null;
     public ?string $deviceId = null;
@@ -16,6 +22,9 @@ class Event
         $this->eventType = $eventType;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return array_filter([

--- a/src/AmplitudeCookie.php
+++ b/src/AmplitudeCookie.php
@@ -2,6 +2,9 @@
 
 namespace AmplitudeExperiment;
 
+use AmplitudeExperiment\Logger\DefaultLogger;
+use AmplitudeExperiment\Logger\InternalLogger;
+use AmplitudeExperiment\Logger\LogLevel;
 use Exception;
 
 require_once __DIR__ . '/Util.php';
@@ -49,7 +52,7 @@ class AmplitudeCookie
                     'userId' => $userSession['userId'] ?? null,
                 ];
             } catch (\Exception $e) {
-                $logger = initializeLogger(false);
+                $logger = new InternalLogger(new DefaultLogger(), LogLevel::INFO);
                 $logger->error("Error parsing the Amplitude cookie: '{$amplitudeCookie}'. " . $e->getMessage());
                 return [];
             }

--- a/src/Assignment/Assignment.php
+++ b/src/Assignment/Assignment.php
@@ -3,18 +3,25 @@
 namespace AmplitudeExperiment\Assignment;
 
 use AmplitudeExperiment\User;
+use AmplitudeExperiment\Variant;
 
 class Assignment
 {
     public User $user;
+    /**
+     * @var array<string, Variant>
+     */
     public array $variants;
     public int $timestamp;
 
+    /**
+     * @param array<string, Variant> $variants
+     */
     public function __construct(User $user, array $variants)
     {
         $this->user = $user;
         $this->variants = $variants;
-        $this->timestamp = floor(microtime(true) * 1000);
+        $this->timestamp = (int) floor(microtime(true) * 1000);
     }
 
     public function canonicalize(): string

--- a/src/Assignment/AssignmentConfig.php
+++ b/src/Assignment/AssignmentConfig.php
@@ -6,15 +6,27 @@ use AmplitudeExperiment\Amplitude\AmplitudeConfig;
 
 /**
  * Configuration options for assignment tracking. This is an object that can be created using
- * a {@link AssignmentConfigBuilder}. Example usage:
+ * a {@link AssignmentConfigBuilder}, which also sets options for {@link AmplitudeConfig}. Example usage:
  *
- * AssignmentConfigBuilder::builder('api-key')->build()
+ * ```
+ * AssignmentConfigBuilder::builder('api-key')->minIdLength(10)->build();
+ * ```
  */
 
 class AssignmentConfig
 {
+    /**
+     * The Amplitude Analytics API key.
+     */
     public string $apiKey;
+    /**
+     * The maximum number of assignments stored in the assignment cache
+     */
     public int $cacheCapacity;
+    /**
+     * Configuration options for the underlying {@link Amplitude} client. This is created when
+     * calling {@link AssignmentConfigBuilder::build()} and does not need to be explicitly set.
+     */
     public AmplitudeConfig $amplitudeConfig;
 
     const DEFAULTS = [

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -2,16 +2,17 @@
 
 namespace AmplitudeExperiment\Assignment;
 
+use AmplitudeExperiment\Amplitude\AmplitudeConfig;
 use AmplitudeExperiment\Amplitude\AmplitudeConfigBuilder;
 
 /**
  * Extends AmplitudeConfigBuilder to allow configuration {@link AmplitudeConfig} of underlying {@link Amplitude} client.
  */
-
 class AssignmentConfigBuilder extends AmplitudeConfigBuilder
 {
     protected string $apiKey;
     protected int $cacheCapacity = AssignmentConfig::DEFAULTS['cacheCapacity'];
+
     public function __construct(string $apiKey)
     {
         parent::__construct();
@@ -24,7 +25,7 @@ class AssignmentConfigBuilder extends AmplitudeConfigBuilder
         return $this;
     }
 
-    public function build(): AssignmentConfig
+    public function build()
     {
         return new AssignmentConfig(
             $this->apiKey,

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -25,6 +25,9 @@ class AssignmentConfigBuilder extends AmplitudeConfigBuilder
         return $this;
     }
 
+    /**
+     * @phpstan-ignore-next-line
+     */
     public function build()
     {
         return new AssignmentConfig(

--- a/src/Assignment/LRUCache.php
+++ b/src/Assignment/LRUCache.php
@@ -2,38 +2,59 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-class ListNode {
-    public $prev;
-    public $next;
+class ListNode
+{
+    public ?ListNode $prev = null;
+    public ?ListNode $next = null;
+    /**
+     * @var mixed
+     */
     public $data;
 
-    public function __construct($data) {
+    /**
+     * @param mixed $data
+     */
+    public function __construct($data)
+    {
         $this->prev = null;
         $this->next = null;
         $this->data = $data;
     }
 }
 
-class CacheItem {
-    public $key;
+class CacheItem
+{
+    public string $key;
+    /**
+     * @var mixed
+     */
     public $value;
-    public $createdAt;
+    public int $createdAt;
 
-    public function __construct($key, $value) {
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $key, $value)
+    {
         $this->key = $key;
         $this->value = $value;
-        $this->createdAt = floor(microtime(true) * 1000);
+        $this->createdAt = (int) floor(microtime(true) * 1000);
     }
 }
 
-class LRUCache {
-    private $capacity;
-    private $ttlMillis;
-    private $cache;
-    private $head;
-    private $tail;
+class LRUCache
+{
+    private int $capacity;
+    private int $ttlMillis;
+    /**
+     * @var array<string, ListNode>
+     */
+    private array $cache;
+    private ?ListNode $head = null;
+    private ?ListNode $tail = null;
 
-    public function __construct($capacity, $ttlMillis) {
+    public function __construct(int $capacity, int $ttlMillis)
+    {
         $this->capacity = $capacity;
         $this->ttlMillis = $ttlMillis;
         $this->cache = [];
@@ -41,7 +62,11 @@ class LRUCache {
         $this->tail = null;
     }
 
-    public function put($key, $value): void {
+    /**
+     * @param mixed $value
+     */
+    public function put(string $key, $value): void
+    {
         if (isset($this->cache[$key])) {
             $this->removeFromList($key);
         } elseif (count($this->cache) >= $this->capacity) {
@@ -54,7 +79,11 @@ class LRUCache {
         $this->insertToList($node);
     }
 
-    public function get($key) {
+    /**
+     * @return mixed
+     */
+    public function get(string $key)
+    {
         if (isset($this->cache[$key])) {
             $node = $this->cache[$key];
             $timeElapsed = floor(microtime(true) * 1000) - $node->data->createdAt;
@@ -72,24 +101,28 @@ class LRUCache {
         return null;
     }
 
-    public function remove($key): void {
+    public function remove(string $key): void
+    {
         $this->removeFromList($key);
         unset($this->cache[$key]);
     }
 
-    public function clear(): void {
+    public function clear(): void
+    {
         $this->cache = [];
         $this->head = null;
         $this->tail = null;
     }
 
-    private function evictLRU(): void {
+    private function evictLRU(): void
+    {
         if ($this->head) {
             $this->remove($this->head->data->key);
         }
     }
 
-    private function removeFromList($key): void {
+    private function removeFromList(string $key): void
+    {
         $node = $this->cache[$key];
 
         if ($node->prev) {
@@ -105,7 +138,8 @@ class LRUCache {
         }
     }
 
-    private function insertToList($node): void {
+    private function insertToList(ListNode $node): void
+    {
         if ($this->tail) {
             $this->tail->next = $node;
             $node->prev = $this->tail;
@@ -117,4 +151,3 @@ class LRUCache {
         }
     }
 }
-

--- a/src/EvaluationCore/EvaluationEngine.php
+++ b/src/EvaluationCore/EvaluationEngine.php
@@ -112,7 +112,7 @@ class EvaluationEngine
 
     private function getHash(string $key): int
     {
-        return murmurhash3_int($key);
+        return Murmur3::hash3_int($key);
     }
 
     private function bucket(array $target, array $segment): ?string

--- a/src/EvaluationCore/Murmur3.php
+++ b/src/EvaluationCore/Murmur3.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AmplitudeExperiment\EvaluationCore;
+
+class Murmur3 {
+
+    /**
+     * @param  string $key   Text to hash.
+     * @param  integer $seed  Positive integer only
+     * @return integer 32-bit positive integer hash
+     */
+    public static function hash3_int(string $key, int $seed=0) : int {
+        $key  = array_values(unpack('C*', $key));
+        $klen = count($key);
+        $h1   = $seed < 0 ? -$seed : $seed;
+        $remainder = $i = 0;
+        for ($bytes=$klen-($remainder=$klen&3) ; $i < $bytes ; ) {
+            $k1 = $key[$i]
+                | ($key[++$i] << 8)
+                | ($key[++$i] << 16)
+                | ($key[++$i] << 24);
+            ++$i;
+            $k1  = (((($k1 & 0xffff) * 0xcc9e2d51) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0xcc9e2d51) & 0xffff) << 16))) & 0xffffffff;
+            $k1  = $k1 << 15 | ($k1 >= 0 ? $k1 >> 17 : (($k1 & 0x7fffffff) >> 17) | 0x4000);
+            $k1  = (((($k1 & 0xffff) * 0x1b873593) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0x1b873593) & 0xffff) << 16))) & 0xffffffff;
+            $h1 ^= $k1;
+            $h1  = $h1 << 13 | ($h1 >= 0 ? $h1 >> 19 : (($h1 & 0x7fffffff) >> 19) | 0x1000);
+            $h1b = (((($h1 & 0xffff) * 5) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 5) & 0xffff) << 16))) & 0xffffffff;
+            $h1  = ((($h1b & 0xffff) + 0x6b64) + ((((($h1b >= 0 ? $h1b >> 16 : (($h1b & 0x7fffffff) >> 16) | 0x8000)) + 0xe654) & 0xffff) << 16));
+        }
+        $k1 = 0;
+        switch ($remainder) {
+            case 3: $k1 ^= $key[$i + 2] << 16;
+            case 2: $k1 ^= $key[$i + 1] << 8;
+            case 1: $k1 ^= $key[$i];
+                $k1  = ((($k1 & 0xffff) * 0xcc9e2d51) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0xcc9e2d51) & 0xffff) << 16)) & 0xffffffff;
+                $k1  = $k1 << 15 | ($k1 >= 0 ? $k1 >> 17 : (($k1 & 0x7fffffff) >> 17) | 0x4000);
+                $k1  = ((($k1 & 0xffff) * 0x1b873593) + ((((($k1 >= 0 ? $k1 >> 16 : (($k1 & 0x7fffffff) >> 16) | 0x8000)) * 0x1b873593) & 0xffff) << 16)) & 0xffffffff;
+                $h1 ^= $k1;
+        }
+        $h1 ^= $klen;
+        $h1 ^= ($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000);
+        $h1  = ((($h1 & 0xffff) * 0x85ebca6b) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+        $h1 ^= ($h1 >= 0 ? $h1 >> 13 : (($h1 & 0x7fffffff) >> 13) | 0x40000);
+        $h1  = (((($h1 & 0xffff) * 0xc2b2ae35) + ((((($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000)) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
+        $h1 ^= ($h1 >= 0 ? $h1 >> 16 : (($h1 & 0x7fffffff) >> 16) | 0x8000);
+        return $h1;
+    }
+}

--- a/src/Experiment.php
+++ b/src/Experiment.php
@@ -9,7 +9,13 @@ use AmplitudeExperiment\Remote\RemoteEvaluationConfig;
 
 class Experiment
 {
+    /**
+     * @var array<string, RemoteEvaluationClient>
+     */
     private array $remoteInstances = [];
+    /**
+     * @var array<string, LocalEvaluationClient>
+     */
     private array $localInstances = [];
 
     /**

--- a/src/Flag/FlagConfigFetcher.php
+++ b/src/Flag/FlagConfigFetcher.php
@@ -2,72 +2,53 @@
 
 namespace AmplitudeExperiment\Flag;
 
+use AmplitudeExperiment\Http\FetchClientInterface;
 use AmplitudeExperiment\Local\LocalEvaluationConfig;
-use AmplitudeExperiment\Util;
-use Exception;
-use GuzzleHttp\Client;
-use GuzzleHttp\Promise\PromiseInterface;
-use Monolog\Logger;
-use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
-use function AmplitudeExperiment\initializeLogger;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../Version.php';
-require_once __DIR__ . '/../Util.php';
-
-const FLAG_CONFIG_TIMEOUT = 5000;
 
 class FlagConfigFetcher
 {
-    private Logger $logger;
+    private LoggerInterface $logger;
     private string $apiKey;
     private string $serverUrl;
-    private Client $httpClient;
+    private FetchClientInterface $httpClient;
 
-    public function __construct(string $apiKey, bool $debug, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
+    public function __construct(string $apiKey, LoggerInterface $logger, FetchClientInterface $fetchClient, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
     {
         $this->apiKey = $apiKey;
         $this->serverUrl = $serverUrl;
-        $this->httpClient = new Client();
-        $this->logger = initializeLogger($debug);
+        $this->logger = $logger;
+        $this->httpClient = $fetchClient;
     }
 
     /**
      * Fetch local evaluation mode flag configs from the Experiment API server.
      * These flag configs can be used to perform local evaluation.
      *
-     * @return PromiseInterface
+     * @throws ClientExceptionInterface
      */
-    public function fetch(): PromiseInterface
+    public function fetch(): array
     {
         $endpoint = $this->serverUrl . '/sdk/v2/flags?v=0';
-        $headers = [
-            'Authorization' => 'Api-Key ' . $this->apiKey,
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/json;charset=utf-8',
-            'X-Amp-Exp-Library' => 'experiment-php-server/' . VERSION,
-        ];
+        $request = $this->httpClient->createRequest('GET', $endpoint)
+            ->withHeader('Authorization', 'Api-Key ' . $this->apiKey)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('X-Amp-Exp-Library', 'experiment-php-server/' . VERSION);
         $this->logger->debug('[Experiment] Fetch flag configs');
-        $promise = $this->httpClient->requestAsync('GET', $endpoint, [
-            'headers' => $headers,
-            'timeout' => FLAG_CONFIG_TIMEOUT / 1000,
-        ]);
 
-        return $promise->then(
-            function (ResponseInterface $response) {
-                // Check if the HTTP status code is not 200
-                if ($response->getStatusCode() !== 200) {
-                    $errorMessage = '[Experiment] Fetch flag configs - received error response: ' . $response->getStatusCode() . ': ' . $response->getBody();
-                    throw new RuntimeException($errorMessage);
-                }
-                $this->logger->debug('[Experiment] Got flag configs: ' . $response->getBody());
-                return $this->parse(json_decode($response->getBody(), true));
-            },
-            function (Exception $reason) {
-                $this->logger->error('[Experiment] Fetch flag configs - received error response: ' . $reason->getMessage());
-                throw $reason;
-            }
-        );
+        $fetchClient = $this->httpClient->getClient();
+
+        $response = $fetchClient->sendRequest($request);
+        if ($response->getStatusCode() !== 200) {
+            $this->logger->error('[Experiment] Fetch flag configs - received error response: ' . $response->getStatusCode() . ': ' . $response->getBody());
+            return [];
+        }
+        $this->logger->debug('[Experiment] Got flag configs: ' . $response->getBody());
+        return $this->parse(json_decode($response->getBody(), true));
+
     }
 
     private function parse(array $flagConfigs): array

--- a/src/Flag/FlagConfigFetcher.php
+++ b/src/Flag/FlagConfigFetcher.php
@@ -2,7 +2,7 @@
 
 namespace AmplitudeExperiment\Flag;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Local\LocalEvaluationConfig;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
@@ -14,9 +14,9 @@ class FlagConfigFetcher
     private LoggerInterface $logger;
     private string $apiKey;
     private string $serverUrl;
-    private FetchClientInterface $httpClient;
+    private HttpClientInterface $httpClient;
 
-    public function __construct(string $apiKey, LoggerInterface $logger, FetchClientInterface $fetchClient, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
+    public function __construct(string $apiKey, LoggerInterface $logger, HttpClientInterface $fetchClient, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
     {
         $this->apiKey = $apiKey;
         $this->serverUrl = $serverUrl;

--- a/src/Flag/FlagConfigFetcher.php
+++ b/src/Flag/FlagConfigFetcher.php
@@ -16,12 +16,12 @@ class FlagConfigFetcher
     private string $serverUrl;
     private HttpClientInterface $httpClient;
 
-    public function __construct(string $apiKey, LoggerInterface $logger, HttpClientInterface $fetchClient, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
+    public function __construct(string $apiKey, LoggerInterface $logger, HttpClientInterface $httpClient, string $serverUrl = LocalEvaluationConfig::DEFAULTS["serverUrl"])
     {
         $this->apiKey = $apiKey;
         $this->serverUrl = $serverUrl;
         $this->logger = $logger;
-        $this->httpClient = $fetchClient;
+        $this->httpClient = $httpClient;
     }
 
     /**
@@ -40,9 +40,9 @@ class FlagConfigFetcher
             ->withHeader('X-Amp-Exp-Library', 'experiment-php-server/' . VERSION);
         $this->logger->debug('[Experiment] Fetch flag configs');
 
-        $fetchClient = $this->httpClient->getClient();
+        $httpClient = $this->httpClient->getClient();
 
-        $response = $fetchClient->sendRequest($request);
+        $response = $httpClient->sendRequest($request);
         if ($response->getStatusCode() !== 200) {
             $this->logger->error('[Experiment] Fetch flag configs - received error response: ' . $response->getStatusCode() . ': ' . $response->getBody());
             return [];

--- a/src/Flag/FlagConfigFetcher.php
+++ b/src/Flag/FlagConfigFetcher.php
@@ -28,6 +28,7 @@ class FlagConfigFetcher
      * Fetch local evaluation mode flag configs from the Experiment API server.
      * These flag configs can be used to perform local evaluation.
      *
+     * @return array<array<mixed>> The flag configs
      * @throws ClientExceptionInterface
      */
     public function fetch(): array
@@ -51,6 +52,10 @@ class FlagConfigFetcher
 
     }
 
+    /**
+     * @param array<array<mixed>> $flagConfigs
+     * @return array<array<mixed>>
+     */
     private function parse(array $flagConfigs): array
     {
         $flagConfigsRecord = [];

--- a/src/Flag/FlagConfigService.php
+++ b/src/Flag/FlagConfigService.php
@@ -9,8 +9,15 @@ class FlagConfigService
 {
     private LoggerInterface $logger;
     public FlagConfigFetcher $fetcher;
+
+    /**
+     * @var array<string, mixed>
+     */
     public array $cache;
 
+    /**
+     * @param array<string, mixed> $bootstrap
+     */
     public function __construct(FlagConfigFetcher $fetcher, LoggerInterface $logger, array $bootstrap)
     {
         $this->fetcher = $fetcher;
@@ -18,7 +25,7 @@ class FlagConfigService
         $this->cache = $bootstrap;
     }
 
-    public function start()
+    public function start(): void
     {
         $this->logger->debug('[Experiment] Flag service - start');
 
@@ -26,7 +33,7 @@ class FlagConfigService
         $this->refresh();
     }
 
-    private function refresh()
+    private function refresh(): void
     {
         $this->logger->debug('[Experiment] Flag config update');
         try {
@@ -37,6 +44,9 @@ class FlagConfigService
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getFlagConfigs(): array
     {
         return $this->cache;

--- a/src/Flag/FlagConfigService.php
+++ b/src/Flag/FlagConfigService.php
@@ -25,13 +25,7 @@ class FlagConfigService
         $this->cache = $bootstrap;
     }
 
-    public function start(): void
-    {
-        $this->logger->debug('[Experiment] Flag service - start');
-        $this->refresh();
-    }
-
-    private function refresh(): void
+    public function refresh(): void
     {
         $this->logger->debug('[Experiment] Flag config update');
         try {

--- a/src/Flag/FlagConfigService.php
+++ b/src/Flag/FlagConfigService.php
@@ -28,8 +28,6 @@ class FlagConfigService
     public function start(): void
     {
         $this->logger->debug('[Experiment] Flag service - start');
-
-        // Fetch initial flag configs and await the result.
         $this->refresh();
     }
 

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AmplitudeExperiment\Http;
+
+
+use Psr\Http\Client\ClientInterface;
+
+interface FetchClientInterface
+{
+    public function getClient(): ClientInterface;
+    public function createRequest(string $method, string $uri);
+}

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -4,9 +4,10 @@ namespace AmplitudeExperiment\Http;
 
 
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 
 interface FetchClientInterface
 {
     public function getClient(): ClientInterface;
-    public function createRequest(string $method, string $uri);
+    public function createRequest(string $method, string $uri) : RequestInterface;
 }

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -8,6 +8,12 @@ use Psr\Http\Message\RequestInterface;
 
 interface FetchClientInterface
 {
+    /**
+     * return a Psr ClientInterface
+     */
     public function getClient(): ClientInterface;
+    /**
+     * return a Psr RequestInterface to be sent by the client
+     */
     public function createRequest(string $method, string $uri) : RequestInterface;
 }

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -9,11 +9,11 @@ use Psr\Http\Message\RequestInterface;
 interface FetchClientInterface
 {
     /**
-     * return a Psr ClientInterface
+     * return a Psr Client
      */
     public function getClient(): ClientInterface;
     /**
-     * return a Psr RequestInterface to be sent by the client
+     * return a Psr Request to be sent by the client
      */
     public function createRequest(string $method, string $uri) : RequestInterface;
 }

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -9,11 +9,11 @@ use Psr\Http\Message\RequestInterface;
 interface FetchClientInterface
 {
     /**
-     * return a Psr Client
+     * Return the underlying PSR HTTP Client
      */
     public function getClient(): ClientInterface;
     /**
-     * return a Psr Request to be sent by the client
+     * Return a PSR Request to be sent by the underlying PSR HTTP Client
      */
     public function createRequest(string $method, string $uri, ?string $body = null) : RequestInterface;
 }

--- a/src/Http/FetchClientInterface.php
+++ b/src/Http/FetchClientInterface.php
@@ -15,5 +15,5 @@ interface FetchClientInterface
     /**
      * return a Psr Request to be sent by the client
      */
-    public function createRequest(string $method, string $uri) : RequestInterface;
+    public function createRequest(string $method, string $uri, ?string $body = null) : RequestInterface;
 }

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace AmplitudeExperiment\Http;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Client\ClientInterface;
+
+const GUZZLE_DEFAULTS = [
+    /**
+     * The request socket timeout, in milliseconds.
+     */
+    'fetchTimeoutMillis' => 10000,
+    /**
+     * The number of retries to attempt before failing
+     */
+    'fetchRetries' => 8,
+    /**
+     * Retry backoff minimum (starting backoff delay) in milliseconds. The minimum backoff is scaled by
+     * `fetchRetryBackoffScalar` after each retry failure.
+     */
+    'fetchRetryBackoffMinMillis' => 500,
+    /**
+     * Retry backoff maximum in milliseconds. If the scaled backoff is greater than the max, the max is
+     * used for all subsequent retries.
+     */
+    'fetchRetryBackoffMaxMillis' => 10000,
+    /**
+     * Scales the minimum backoff exponentially.
+     */
+    'fetchRetryBackoffScalar' => 1.5,
+    /**
+     * The request timeout for retrying fetch requests.
+     */
+    'fetchRetryTimeoutMillis' => 10000
+];
+
+class GuzzleFetchClient implements FetchClientInterface
+{
+    private Client $client;
+    private array $config;
+
+    public function __construct(array $config)
+    {
+        $handlerStack = HandlerStack::create();
+        $this->config = array_merge(GUZZLE_DEFAULTS, $config);
+
+        // Add middleware for retries
+        $handlerStack->push(Middleware::retry(
+            function ($retries, Request $request, $response = null, $exception = null) {
+                // Retry if the maximum number of retries is not reached and an exception occurred
+                return $retries < $this->config['fetchRetries'] && $exception instanceof \Exception;
+            },
+            function ($retries) {
+                // Calculate delay
+                return $this->calculateDelayMillis($retries);
+            }
+        ));
+
+        // Create a Guzzle client with the custom handler stack
+        $this->client = new Client(['handler' => $handlerStack, RequestOptions::TIMEOUT => $this->config['fetchTimeoutMillis'] / 1000]);
+    }
+
+    public function getClient(): ClientInterface
+    {
+        return $this->client;
+    }
+
+    public function createRequest(string $method, string $uri): Request
+    {
+        return new Request($method, $uri);
+    }
+
+
+    protected function calculateDelayMillis($iteration): int
+    {
+        $delayMillis = $this->config['fetchRetryBackoffMinMillis'];
+
+        for ($i = 0; $i < $iteration; $i++) {
+            $delayMillis = min(
+                $delayMillis * $this->config['fetchRetryBackoffScalar'],
+                $this->config['fetchRetryBackoffMaxMillis']
+            );
+        }
+        return $delayMillis;
+    }
+}

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -38,6 +38,9 @@ const GUZZLE_DEFAULTS = [
     'fetchRetryTimeoutMillis' => 10000
 ];
 
+/**
+ * A default FetchClientInterface implementation that uses Guzzle.
+ */
 class GuzzleFetchClient implements FetchClientInterface
 {
     private Client $client;

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -81,10 +81,7 @@ class GuzzleFetchClient implements FetchClientInterface
 
     public function createRequest(string $method, string $uri, ?string $body = null): Request
     {
-        if ($body !== null) {
-            return new Request($method, $uri, [], $body);
-        }
-        return new Request($method, $uri);
+        return new Request($method, $uri, [], $body);
     }
 
 

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -2,6 +2,7 @@
 
 namespace AmplitudeExperiment\Http;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -61,7 +62,7 @@ class GuzzleFetchClient implements FetchClientInterface
         $handlerStack->push(Middleware::retry(
             function ($retries, Request $request, $response = null, $exception = null) {
                 // Retry if the maximum number of retries is not reached and an exception occurred
-                return $retries < $this->config['fetchRetries'] && $exception instanceof \Exception;
+                return $retries < $this->config['fetchRetries'] && $exception instanceof Exception;
             },
             function ($retries) {
                 // Calculate delay
@@ -78,8 +79,11 @@ class GuzzleFetchClient implements FetchClientInterface
         return $this->client;
     }
 
-    public function createRequest(string $method, string $uri): Request
+    public function createRequest(string $method, string $uri, ?string $body = null): Request
     {
+        if ($body !== null) {
+            return new Request($method, $uri, [], $body);
+        }
         return new Request($method, $uri);
     }
 

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -89,7 +89,7 @@ class GuzzleFetchClient implements FetchClientInterface
     {
         $delayMillis = $this->config['fetchRetryBackoffMinMillis'];
 
-        for ($i = 0; $i < $iteration; $i++) {
+        for ($i = 1; $i < $iteration; $i++) {
             $delayMillis = min(
                 $delayMillis * $this->config['fetchRetryBackoffScalar'],
                 $this->config['fetchRetryBackoffMaxMillis']

--- a/src/Http/GuzzleFetchClient.php
+++ b/src/Http/GuzzleFetchClient.php
@@ -41,8 +41,14 @@ const GUZZLE_DEFAULTS = [
 class GuzzleFetchClient implements FetchClientInterface
 {
     private Client $client;
+    /**
+     * @var array<string, mixed>
+     */
     private array $config;
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function __construct(array $config)
     {
         $handlerStack = HandlerStack::create();
@@ -75,7 +81,7 @@ class GuzzleFetchClient implements FetchClientInterface
     }
 
 
-    protected function calculateDelayMillis($iteration): int
+    protected function calculateDelayMillis(int $iteration): int
     {
         $delayMillis = $this->config['fetchRetryBackoffMinMillis'];
 

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -6,7 +6,7 @@ namespace AmplitudeExperiment\Http;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 
-interface FetchClientInterface
+interface HttpClientInterface
 {
     /**
      * Return the underlying PSR HTTP Client

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -2,10 +2,12 @@
 
 namespace AmplitudeExperiment\Http;
 
-
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * Interface for the HTTP clients set in {@link RemoteEvaluationConfig} and {@link LocalEvaluationConfig}.
+ */
 interface HttpClientInterface
 {
     /**
@@ -14,6 +16,9 @@ interface HttpClientInterface
     public function getClient(): ClientInterface;
     /**
      * Return a PSR Request to be sent by the underlying PSR HTTP Client
+     * @param string $method The HTTP method to use
+     * @param string $uri The URI to send the request to
+     * @param string|null $body The body of the request
      */
     public function createRequest(string $method, string $uri, ?string $body = null) : RequestInterface;
 }

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -14,6 +14,7 @@ use AmplitudeExperiment\Http\GuzzleFetchClient;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\User;
+use AmplitudeExperiment\Variant;
 use Psr\Log\LoggerInterface;
 use function AmplitudeExperiment\EvaluationCore\topologicalSort;
 
@@ -38,14 +39,14 @@ class LocalEvaluationClient
         $httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
         $fetcher = new FlagConfigFetcher($apiKey, $this->logger, $httpClient, $this->config->serverUrl);
         $this->flagConfigService = new FlagConfigService($fetcher, $this->logger, $this->config->bootstrap);
-        $this->initializeAssignmentService($config->assignmentConfig);
+        $this->initializeAssignmentService($this->config->assignmentConfig);
         $this->evaluation = new EvaluationEngine();
     }
 
     /**
      * Fetch initial flag configurations.
      */
-    public function start()
+    public function start(): void
     {
         $this->flagConfigService->start();
     }
@@ -57,10 +58,10 @@ class LocalEvaluationClient
      * flagKeys argument. If flagKeys is missing or empty, all flags in the
      * {@link FlagConfigService} will be evaluated.
      *
-     * @param $user User The user to evaluate
-     * @param $flagKeys array The flags to evaluate with the user. If empty, all flags
+     * @param User $user The user to evaluate
+     * @param array<string> $flagKeys The flags to evaluate with the user. If empty, all flags
      * from the flag cache are evaluated.
-     * @returns array evaluated variants
+     * @return array<Variant> evaluated variants
      */
     public function evaluate(User $user, array $flagKeys = []): array
     {

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -44,11 +44,11 @@ class LocalEvaluationClient
     }
 
     /**
-     * Fetch initial flag configurations.
+     * Fetch latest flag configurations.
      */
-    public function start(): void
+    public function refreshFlagConfigs(): void
     {
-        $this->flagConfigService->start();
+        $this->flagConfigService->refresh();
     }
 
     /**
@@ -78,6 +78,15 @@ class LocalEvaluationClient
             $this->assignmentService->track(new Assignment($user, $results));
         }
         return $results;
+    }
+
+
+    /**
+     * @return array<string, mixed> flag configurations.
+     */
+    public function getFlagConfigs(): array
+    {
+        return $this->flagConfigService->getFlagConfigs();
     }
 
     private function initializeAssignmentService(?AssignmentConfig $config): void

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -73,7 +73,7 @@ class LocalEvaluationClient
         }
         $this->logger->debug('[Experiment] Evaluate - user: ' . json_encode($user->toArray()) . ' with flags: ' . json_encode($flags));
         $results = array_map('AmplitudeExperiment\Variant::convertEvaluationVariantToVariant', $this->evaluation->evaluate($user->toEvaluationContext(), $flags));
-        $this->logger->debug('[Experiment] Evaluate - variants:', $results);
+        $this->logger->debug('[Experiment] Evaluate - variants:' . json_encode($results));
         if ($this->assignmentService) {
             $this->assignmentService->track(new Assignment($user, $results));
         }

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -36,7 +36,7 @@ class LocalEvaluationClient
     {
         $this->config = $config ?? LocalEvaluationConfig::builder()->build();
         $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
-        $httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
+        $httpClient = $config->httpClient ?? $this->config->httpClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
         $fetcher = new FlagConfigFetcher($apiKey, $this->logger, $httpClient, $this->config->serverUrl);
         $this->flagConfigService = new FlagConfigService($fetcher, $this->logger, $this->config->bootstrap);
         $this->initializeAssignmentService($this->config->assignmentConfig);

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -10,15 +10,14 @@ use AmplitudeExperiment\Assignment\AssignmentService;
 use AmplitudeExperiment\EvaluationCore\EvaluationEngine;
 use AmplitudeExperiment\Flag\FlagConfigFetcher;
 use AmplitudeExperiment\Flag\FlagConfigService;
+use AmplitudeExperiment\Http\GuzzleFetchClient;
+use AmplitudeExperiment\Logger\DefaultLogger;
+use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\User;
-use AmplitudeExperiment\Util;
-use GuzzleHttp\Promise\PromiseInterface;
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 use function AmplitudeExperiment\EvaluationCore\topologicalSort;
-use function AmplitudeExperiment\initializeLogger;
 
 require_once __DIR__ . '/../EvaluationCore/Util.php';
-require_once __DIR__ . '/../Util.php';
 
 /**
  * Experiment client for evaluating variants for a user locally.
@@ -26,34 +25,29 @@ require_once __DIR__ . '/../Util.php';
  */
 class LocalEvaluationClient
 {
-    private string $apiKey;
     private LocalEvaluationConfig $config;
     private FlagConfigService $flagConfigService;
     private EvaluationEngine $evaluation;
-    private Logger $logger;
+    private LoggerInterface $logger;
     private ?AssignmentService $assignmentService = null;
 
     public function __construct(string $apiKey, ?LocalEvaluationConfig $config = null)
     {
-        $this->apiKey = $apiKey;
         $this->config = $config ?? LocalEvaluationConfig::builder()->build();
-        $fetcher = new FlagConfigFetcher($apiKey, $this->config->debug, $this->config->serverUrl);
-        $this->flagConfigService = new FlagConfigService($fetcher, $this->config->debug, $this->config->bootstrap);
-        $this->logger = initializeLogger($this->config->debug);
+        $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
+        $httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
+        $fetcher = new FlagConfigFetcher($apiKey, $this->logger, $httpClient, $this->config->serverUrl);
+        $this->flagConfigService = new FlagConfigService($fetcher, $this->logger, $this->config->bootstrap);
         $this->initializeAssignmentService($config->assignmentConfig);
         $this->evaluation = new EvaluationEngine();
     }
 
     /**
      * Fetch initial flag configurations.
-     *
-     * The promise returned by this function is resolved when the initial call
-     * to fetch the flag configuration completes.
-     *
      */
-    public function start(): PromiseInterface
+    public function start()
     {
-        return $this->flagConfigService->start();
+        $this->flagConfigService->start();
     }
 
     /**
@@ -77,7 +71,7 @@ class LocalEvaluationClient
             $this->logger->error('[Experiment] Evaluate - error sorting flags: ' . $e->getMessage());
         }
         $this->logger->debug('[Experiment] Evaluate - user: ' . json_encode($user->toArray()) . ' with flags: ' . json_encode($flags));
-        $results = array_map('AmplitudeExperiment\Variant::convertEvaluationVariantToVariant',$this->evaluation->evaluate($user->toEvaluationContext(), $flags));
+        $results = array_map('AmplitudeExperiment\Variant::convertEvaluationVariantToVariant', $this->evaluation->evaluate($user->toEvaluationContext(), $flags));
         $this->logger->debug('[Experiment] Evaluate - variants:', $results);
         if ($this->assignmentService) {
             $this->assignmentService->track(new Assignment($user, $results));
@@ -90,7 +84,7 @@ class LocalEvaluationClient
         if ($config) {
             $this->assignmentService = new AssignmentService(
                 new Amplitude($config->apiKey,
-                    $this->config->debug,
+                    $this->logger,
                     $config->amplitudeConfig),
                 new AssignmentFilter($config->cacheCapacity));
         }

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -10,7 +10,7 @@ use AmplitudeExperiment\Assignment\AssignmentService;
 use AmplitudeExperiment\EvaluationCore\EvaluationEngine;
 use AmplitudeExperiment\Flag\FlagConfigFetcher;
 use AmplitudeExperiment\Flag\FlagConfigService;
-use AmplitudeExperiment\Http\GuzzleFetchClient;
+use AmplitudeExperiment\Http\GuzzleHttpClient;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\User;
@@ -36,7 +36,7 @@ class LocalEvaluationClient
     {
         $this->config = $config ?? LocalEvaluationConfig::builder()->build();
         $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
-        $httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
+        $httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
         $fetcher = new FlagConfigFetcher($apiKey, $this->logger, $httpClient, $this->config->serverUrl);
         $this->flagConfigService = new FlagConfigService($fetcher, $this->logger, $this->config->bootstrap);
         $this->initializeAssignmentService($this->config->assignmentConfig);

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -3,13 +3,20 @@
 namespace AmplitudeExperiment\Local;
 
 use AmplitudeExperiment\Assignment\AssignmentConfig;
+use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Logger\LogLevel;
+use Psr\Log\LoggerInterface;
 
 class LocalEvaluationConfig
 {
     /**
-     * Set to true to log some extra information to the console.
+     * Set to use custom logger. If not set, a {@link DefaultLogger} is used.
      */
-    public bool $debug;
+    public ?LoggerInterface $logger;
+    /**
+     * The log level to use for the logger.
+     */
+    public int $logLevel;
     /**
      * The server endpoint from which to request variants.
      */
@@ -21,20 +28,33 @@ class LocalEvaluationConfig
      */
     public array $bootstrap;
     public ?AssignmentConfig $assignmentConfig;
+    /**
+     * The underlying HTTP client to use for requests.
+     */
+    public ?FetchClientInterface $fetchClient;
+    /**
+     * The configuration for the underlying default Guzzle client.
+     */
+    public array $guzzleClientConfig;
 
     const DEFAULTS = [
-        'debug' => false,
+        'logger' => null,
+        'logLevel' => LogLevel::INFO,
         'serverUrl' => 'https://api.lab.amplitude.com',
         'bootstrap' => [],
-        'assignmentConfig' => null
+        'assignmentConfig' => null,
+        'fetchClient' => null,
+        'guzzleClientConfig' => []
     ];
 
-    public function __construct(bool $debug, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig)
-    {
-        $this->debug = $debug;
+    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?FetchClientInterface $fetchClient, array $guzzleClientConfig){
+        $this->logger = $logger;
+        $this->logLevel = $logLevel;
         $this->serverUrl = $serverUrl;
         $this->bootstrap = $bootstrap;
         $this->assignmentConfig = $assignmentConfig;
+        $this->fetchClient = $fetchClient;
+        $this->guzzleClientConfig = $guzzleClientConfig;
     }
 
     public static function builder(): LocalEvaluationConfigBuilder

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -7,6 +7,14 @@ use AmplitudeExperiment\Http\FetchClientInterface;
 use AmplitudeExperiment\Logger\LogLevel;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Configuration options. This is an object that can be created using
+ * a {@link LocalEvaluationConfigBuilder}. Example usage:
+ *
+ *```
+ * LocalEvaluationConfig::builder()->serverUrl("https://api.lab.amplitude.com/")->build();
+ * ```
+ */
 class LocalEvaluationConfig
 {
     /**
@@ -14,7 +22,7 @@ class LocalEvaluationConfig
      */
     public ?LoggerInterface $logger;
     /**
-     * The log level to use for the logger.
+     * The {@link LogLevel} to use for the logger.
      */
     public int $logLevel;
     /**
@@ -29,12 +37,12 @@ class LocalEvaluationConfig
     public array $bootstrap;
     public ?AssignmentConfig $assignmentConfig;
     /**
-     * The underlying HTTP client to use for requests, if this is not set, the default GuzzleFetchClient will be used.
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
      */
     public ?FetchClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default Guzzle client. See {@link GUZZLE_DEFAULTS} for defaults.
+     * The configuration for the underlying default {@link GuzzleFetchClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -39,7 +39,7 @@ class LocalEvaluationConfig
     /**
      * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?HttpClientInterface $fetchClient;
+    public ?HttpClientInterface $httpClient;
     /**
      * @var array<string, mixed>
      * The configuration for the underlying default {@link GuzzleHttpClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
@@ -52,7 +52,7 @@ class LocalEvaluationConfig
         'serverUrl' => 'https://api.lab.amplitude.com',
         'bootstrap' => [],
         'assignmentConfig' => null,
-        'fetchClient' => null,
+        'httpClient' => null,
         'guzzleClientConfig' => []
     ];
 
@@ -60,14 +60,14 @@ class LocalEvaluationConfig
      * @param array<string, mixed> $guzzleClientConfig
      * @param array<string, mixed> $bootstrap
      */
-    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?HttpClientInterface $fetchClient, array $guzzleClientConfig)
+    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?HttpClientInterface $httpClient, array $guzzleClientConfig)
     {
         $this->logger = $logger;
         $this->logLevel = $logLevel;
         $this->serverUrl = $serverUrl;
         $this->bootstrap = $bootstrap;
         $this->assignmentConfig = $assignmentConfig;
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         $this->guzzleClientConfig = $guzzleClientConfig;
     }
 

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -29,7 +29,7 @@ class LocalEvaluationConfig
     public array $bootstrap;
     public ?AssignmentConfig $assignmentConfig;
     /**
-     * The underlying HTTP client to use for requests.
+     * The underlying HTTP client to use for requests, if this is not set, the default GuzzleFetchClient will be used.
      */
     public ?FetchClientInterface $fetchClient;
     /**

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -3,7 +3,7 @@
 namespace AmplitudeExperiment\Local;
 
 use AmplitudeExperiment\Assignment\AssignmentConfig;
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Logger\LogLevel;
 use Psr\Log\LoggerInterface;
 
@@ -37,12 +37,12 @@ class LocalEvaluationConfig
     public array $bootstrap;
     public ?AssignmentConfig $assignmentConfig;
     /**
-     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?FetchClientInterface $fetchClient;
+    public ?HttpClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default {@link GuzzleFetchClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
+     * The configuration for the underlying default {@link GuzzleHttpClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 
@@ -60,7 +60,7 @@ class LocalEvaluationConfig
      * @param array<string, mixed> $guzzleClientConfig
      * @param array<string, mixed> $bootstrap
      */
-    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?FetchClientInterface $fetchClient, array $guzzleClientConfig)
+    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?HttpClientInterface $fetchClient, array $guzzleClientConfig)
     {
         $this->logger = $logger;
         $this->logLevel = $logLevel;

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -34,7 +34,7 @@ class LocalEvaluationConfig
     public ?FetchClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default Guzzle client.
+     * The configuration for the underlying default Guzzle client. See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -22,8 +22,8 @@ class LocalEvaluationConfig
      */
     public string $serverUrl;
     /**
+     * @var array<string, mixed>
      * Bootstrap the client with a pre-fetched flag configurations.
-     *
      * Useful if you are managing the flag configurations separately.
      */
     public array $bootstrap;
@@ -33,6 +33,7 @@ class LocalEvaluationConfig
      */
     public ?FetchClientInterface $fetchClient;
     /**
+     * @var array<string, mixed>
      * The configuration for the underlying default Guzzle client.
      */
     public array $guzzleClientConfig;
@@ -47,7 +48,12 @@ class LocalEvaluationConfig
         'guzzleClientConfig' => []
     ];
 
-    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?FetchClientInterface $fetchClient, array $guzzleClientConfig){
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     * @param array<string, mixed> $bootstrap
+     */
+    public function __construct(?LoggerInterface $logger, int $logLevel, string $serverUrl, array $bootstrap, ?AssignmentConfig $assignmentConfig, ?FetchClientInterface $fetchClient, array $guzzleClientConfig)
+    {
         $this->logger = $logger;
         $this->logLevel = $logLevel;
         $this->serverUrl = $serverUrl;

--- a/src/Local/LocalEvaluationConfig.php
+++ b/src/Local/LocalEvaluationConfig.php
@@ -48,7 +48,7 @@ class LocalEvaluationConfig
 
     const DEFAULTS = [
         'logger' => null,
-        'logLevel' => LogLevel::INFO,
+        'logLevel' => LogLevel::ERROR,
         'serverUrl' => 'https://api.lab.amplitude.com',
         'bootstrap' => [],
         'assignmentConfig' => null,

--- a/src/Local/LocalEvaluationConfigBuilder.php
+++ b/src/Local/LocalEvaluationConfigBuilder.php
@@ -16,7 +16,7 @@ class LocalEvaluationConfigBuilder
      */
     protected array $bootstrap = LocalEvaluationConfig::DEFAULTS['bootstrap'];
     protected ?AssignmentConfig $assignmentConfig = LocalEvaluationConfig::DEFAULTS['assignmentConfig'];
-    protected ?HttpClientInterface $fetchClient = LocalEvaluationConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $httpClient = LocalEvaluationConfig::DEFAULTS['httpClient'];
     /**
      * @var array<string, mixed>
      */
@@ -59,9 +59,9 @@ class LocalEvaluationConfigBuilder
         return $this;
     }
 
-    public function fetchClient(HttpClientInterface $fetchClient): LocalEvaluationConfigBuilder
+    public function httpClient(HttpClientInterface $httpClient): LocalEvaluationConfigBuilder
     {
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         return $this;
     }
 
@@ -82,7 +82,7 @@ class LocalEvaluationConfigBuilder
             $this->serverUrl,
             $this->bootstrap,
             $this->assignmentConfig,
-            $this->fetchClient,
+            $this->httpClient,
             $this->guzzleClientConfig
         );
     }

--- a/src/Local/LocalEvaluationConfigBuilder.php
+++ b/src/Local/LocalEvaluationConfigBuilder.php
@@ -3,7 +3,7 @@
 namespace AmplitudeExperiment\Local;
 
 use AmplitudeExperiment\Assignment\AssignmentConfig;
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use Psr\Log\LoggerInterface;
 
 class LocalEvaluationConfigBuilder
@@ -16,7 +16,7 @@ class LocalEvaluationConfigBuilder
      */
     protected array $bootstrap = LocalEvaluationConfig::DEFAULTS['bootstrap'];
     protected ?AssignmentConfig $assignmentConfig = LocalEvaluationConfig::DEFAULTS['assignmentConfig'];
-    protected ?FetchClientInterface $fetchClient = LocalEvaluationConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $fetchClient = LocalEvaluationConfig::DEFAULTS['fetchClient'];
     /**
      * @var array<string, mixed>
      */
@@ -59,7 +59,7 @@ class LocalEvaluationConfigBuilder
         return $this;
     }
 
-    public function fetchClient(FetchClientInterface $fetchClient): LocalEvaluationConfigBuilder
+    public function fetchClient(HttpClientInterface $fetchClient): LocalEvaluationConfigBuilder
     {
         $this->fetchClient = $fetchClient;
         return $this;

--- a/src/Local/LocalEvaluationConfigBuilder.php
+++ b/src/Local/LocalEvaluationConfigBuilder.php
@@ -11,9 +11,15 @@ class LocalEvaluationConfigBuilder
     protected ?LoggerInterface $logger = LocalEvaluationConfig::DEFAULTS['logger'];
     protected int $logLevel = LocalEvaluationConfig::DEFAULTS['logLevel'];
     protected string $serverUrl = LocalEvaluationConfig::DEFAULTS['serverUrl'];
+    /**
+     * @var array<string, mixed>
+     */
     protected array $bootstrap = LocalEvaluationConfig::DEFAULTS['bootstrap'];
     protected ?AssignmentConfig $assignmentConfig = LocalEvaluationConfig::DEFAULTS['assignmentConfig'];
     protected ?FetchClientInterface $fetchClient = LocalEvaluationConfig::DEFAULTS['fetchClient'];
+    /**
+     * @var array<string, mixed>
+     */
     protected array $guzzleClientConfig = LocalEvaluationConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
@@ -38,6 +44,9 @@ class LocalEvaluationConfigBuilder
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $bootstrap
+     */
     public function bootstrap(array $bootstrap): LocalEvaluationConfigBuilder
     {
         $this->bootstrap = $bootstrap;
@@ -56,6 +65,9 @@ class LocalEvaluationConfigBuilder
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     */
     public function guzzleClientConfig(array $guzzleClientConfig): LocalEvaluationConfigBuilder
     {
         $this->guzzleClientConfig = $guzzleClientConfig;

--- a/src/Local/LocalEvaluationConfigBuilder.php
+++ b/src/Local/LocalEvaluationConfigBuilder.php
@@ -3,21 +3,32 @@
 namespace AmplitudeExperiment\Local;
 
 use AmplitudeExperiment\Assignment\AssignmentConfig;
+use AmplitudeExperiment\Http\FetchClientInterface;
+use Psr\Log\LoggerInterface;
 
 class LocalEvaluationConfigBuilder
 {
-    protected bool $debug = LocalEvaluationConfig::DEFAULTS['debug'];
+    protected ?LoggerInterface $logger = LocalEvaluationConfig::DEFAULTS['logger'];
+    protected int $logLevel = LocalEvaluationConfig::DEFAULTS['logLevel'];
     protected string $serverUrl = LocalEvaluationConfig::DEFAULTS['serverUrl'];
     protected array $bootstrap = LocalEvaluationConfig::DEFAULTS['bootstrap'];
     protected ?AssignmentConfig $assignmentConfig = LocalEvaluationConfig::DEFAULTS['assignmentConfig'];
+    protected ?FetchClientInterface $fetchClient = LocalEvaluationConfig::DEFAULTS['fetchClient'];
+    protected array $guzzleClientConfig = LocalEvaluationConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
     {
     }
 
-    public function debug(bool $debug): LocalEvaluationConfigBuilder
+    public function logger(LoggerInterface $logger): LocalEvaluationConfigBuilder
     {
-        $this->debug = $debug;
+        $this->logger = $logger;
+        return $this;
+    }
+
+    public function logLevel(int $logLevel): LocalEvaluationConfigBuilder
+    {
+        $this->logLevel = $logLevel;
         return $this;
     }
 
@@ -39,13 +50,28 @@ class LocalEvaluationConfigBuilder
         return $this;
     }
 
+    public function fetchClient(FetchClientInterface $fetchClient): LocalEvaluationConfigBuilder
+    {
+        $this->fetchClient = $fetchClient;
+        return $this;
+    }
+
+    public function guzzleClientConfig(array $guzzleClientConfig): LocalEvaluationConfigBuilder
+    {
+        $this->guzzleClientConfig = $guzzleClientConfig;
+        return $this;
+    }
+
     public function build(): LocalEvaluationConfig
     {
         return new LocalEvaluationConfig(
-            $this->debug,
+            $this->logger,
+            $this->logLevel,
             $this->serverUrl,
             $this->bootstrap,
-            $this->assignmentConfig
+            $this->assignmentConfig,
+            $this->fetchClient,
+            $this->guzzleClientConfig
         );
     }
 }

--- a/src/Logger/DefaultLogger.php
+++ b/src/Logger/DefaultLogger.php
@@ -54,6 +54,9 @@ class DefaultLogger implements LoggerInterface
         // Do nothing, only the leveled methods should be used.
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     private static function logMessage(int $level, string $message, array $context = []): void
     {
         $date = new DateTimeImmutable();

--- a/src/Logger/DefaultLogger.php
+++ b/src/Logger/DefaultLogger.php
@@ -7,6 +7,9 @@ namespace AmplitudeExperiment\Logger;
 use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
 
+/**
+ * A default LoggerInterface implementation that logs to error_log.
+ */
 class DefaultLogger implements LoggerInterface
 {
     public function emergency($message, array $context = []): void

--- a/src/Logger/DefaultLogger.php
+++ b/src/Logger/DefaultLogger.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmplitudeExperiment\Logger;
+
+use DateTimeImmutable;
+use Psr\Log\LoggerInterface;
+
+class DefaultLogger implements LoggerInterface
+{
+    public function emergency($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    public function alert($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::ALERT, $message, $context);
+    }
+
+    public function critical($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::CRITICAL, $message, $context);
+    }
+
+    public function error($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::ERROR, $message, $context);
+    }
+
+    public function warning($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::WARNING, $message, $context);
+    }
+
+    public function notice($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::NOTICE, $message, $context);
+    }
+
+    public function info($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::INFO, $message, $context);
+    }
+
+    public function debug($message, array $context = []): void
+    {
+        self::logMessage(LogLevel::DEBUG, $message, $context);
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        // Do nothing, only the leveled methods should be used.
+    }
+
+    private static function logMessage(int $level, string $message, array $context = []): void
+    {
+        $date = new DateTimeImmutable();
+        $timestamp = $date->format('Y-m-d\\TH:i:sP');
+        $level = LogLevel::toString($level);
+        $message = "[$timestamp] AmplitudeExperiment.$level: $message";
+        error_log($message);
+    }
+}

--- a/src/Logger/InternalLogger.php
+++ b/src/Logger/InternalLogger.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace AmplitudeExperiment\Logger;
+
+use Psr\Log\LoggerInterface;
+
+class InternalLogger implements LoggerInterface
+{
+    private LoggerInterface $logger;
+    private int $logLevel;
+
+    public function __construct(LoggerInterface $logger, int $logLevel)
+    {
+        $this->logger = $logger;
+        $this->logLevel = $logLevel;
+    }
+
+    public function emergency($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::EMERGENCY)) {
+            $this->logger->emergency($message, $context);
+        }
+    }
+
+    public function alert($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::ALERT)) {
+            $this->logger->alert($message, $context);
+        }
+    }
+
+    public function critical($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::CRITICAL)) {
+            $this->logger->critical($message, $context);
+        }
+    }
+
+    public function error($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::ERROR)) {
+            $this->logger->error($message, $context);
+        }
+    }
+
+    public function warning($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::WARNING)) {
+            $this->logger->warning($message, $context);
+        }
+    }
+
+    public function notice($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::NOTICE)) {
+            $this->logger->notice($message, $context);
+        }
+    }
+
+    public function info($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::INFO)) {
+            $this->logger->info($message, $context);
+        }
+    }
+
+    public function debug($message, array $context = array())
+    {
+        if ($this->shouldLog(LogLevel::DEBUG)) {
+            $this->logger->debug($message, $context);
+        }
+    }
+
+    public function log($level, $message, array $context = array())
+    {
+        // Do nothing
+    }
+
+    private function shouldLog($level): bool
+    {
+        return $level >= $this->logLevel;
+    }
+}

--- a/src/Logger/InternalLogger.php
+++ b/src/Logger/InternalLogger.php
@@ -76,7 +76,7 @@ class InternalLogger implements LoggerInterface
         // Do nothing
     }
 
-    private function shouldLog($level): bool
+    private function shouldLog(int $level): bool
     {
         return $level >= $this->logLevel;
     }

--- a/src/Logger/InternalLogger.php
+++ b/src/Logger/InternalLogger.php
@@ -15,63 +15,63 @@ class InternalLogger implements LoggerInterface
         $this->logLevel = $logLevel;
     }
 
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::EMERGENCY)) {
             $this->logger->emergency($message, $context);
         }
     }
 
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::ALERT)) {
             $this->logger->alert($message, $context);
         }
     }
 
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::CRITICAL)) {
             $this->logger->critical($message, $context);
         }
     }
 
-    public function error($message, array $context = array())
+    public function error($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::ERROR)) {
             $this->logger->error($message, $context);
         }
     }
 
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::WARNING)) {
             $this->logger->warning($message, $context);
         }
     }
 
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::NOTICE)) {
             $this->logger->notice($message, $context);
         }
     }
 
-    public function info($message, array $context = array())
+    public function info($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::INFO)) {
             $this->logger->info($message, $context);
         }
     }
 
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = []): void
     {
         if ($this->shouldLog(LogLevel::DEBUG)) {
             $this->logger->debug($message, $context);
         }
     }
 
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = []): void
     {
         // Do nothing
     }

--- a/src/Logger/InternalLogger.php
+++ b/src/Logger/InternalLogger.php
@@ -78,6 +78,6 @@ class InternalLogger implements LoggerInterface
 
     private function shouldLog(int $level): bool
     {
-        return $level >= $this->logLevel;
+        return $level <= $this->logLevel;
     }
 }

--- a/src/Logger/LogLevel.php
+++ b/src/Logger/LogLevel.php
@@ -4,7 +4,7 @@ namespace AmplitudeExperiment\Logger;
 
 class LogLevel
 {
-    public const OFF = -1;
+    public const NO_LOG = -1;
     public const EMERGENCY = 0;
     public const ALERT = 1;
     public const CRITICAL = 2;

--- a/src/Logger/LogLevel.php
+++ b/src/Logger/LogLevel.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AmplitudeExperiment\Logger;
+
+class LogLevel
+{
+    public const EMERGENCY = 8;
+    public const ALERT = 7;
+    public const CRITICAL = 6;
+    public const ERROR = 5;
+    public const WARNING = 4;
+    public const NOTICE = 3;
+    public const INFO = 2;
+    public const DEBUG = 1;
+
+    public static function toString(int $level): string
+    {
+        switch ($level) {
+            case self::DEBUG:
+                return 'DEBUG';
+            case self::INFO:
+                return 'INFO';
+            case self::NOTICE:
+                return 'NOTICE';
+            case self::WARNING:
+                return 'WARNING';
+            case self::ERROR:
+                return 'ERROR';
+            case self::CRITICAL:
+                return 'CRITICAL';
+            case self::ALERT:
+                return 'ALERT';
+            case self::EMERGENCY:
+                return 'EMERGENCY';
+            default:
+                return '';
+        }
+    }
+}

--- a/src/Logger/LogLevel.php
+++ b/src/Logger/LogLevel.php
@@ -4,14 +4,15 @@ namespace AmplitudeExperiment\Logger;
 
 class LogLevel
 {
-    public const EMERGENCY = 8;
-    public const ALERT = 7;
-    public const CRITICAL = 6;
-    public const ERROR = 5;
+    public const OFF = -1;
+    public const EMERGENCY = 0;
+    public const ALERT = 1;
+    public const CRITICAL = 2;
+    public const ERROR = 3;
     public const WARNING = 4;
-    public const NOTICE = 3;
-    public const INFO = 2;
-    public const DEBUG = 1;
+    public const NOTICE = 5;
+    public const INFO = 6;
+    public const DEBUG = 7;
 
     public static function toString(int $level): string
     {

--- a/src/Remote/RemoteEvaluationClient.php
+++ b/src/Remote/RemoteEvaluationClient.php
@@ -35,7 +35,7 @@ class RemoteEvaluationClient
     {
         $this->apiKey = $apiKey;
         $this->config = $config ?? RemoteEvaluationConfig::builder()->build();
-        $this->httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
+        $this->httpClient = $config->httpClient ?? $this->config->httpClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
         $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
     }
 
@@ -80,10 +80,10 @@ class RemoteEvaluationClient
             $request = $request->withHeader('X-Amp-Exp-Flag-Keys', base64_encode($flagKeysJson));
         }
 
-        $fetchClient = $this->httpClient->getClient();
+        $httpClient = $this->httpClient->getClient();
 
         try {
-            $response = $fetchClient->sendRequest($request);
+            $response = $httpClient->sendRequest($request);
             if ($response->getStatusCode() != 200) {
                 $this->logger->error('[Experiment] Failed to fetch variants: ' . $response->getBody());
                 return [];

--- a/src/Remote/RemoteEvaluationClient.php
+++ b/src/Remote/RemoteEvaluationClient.php
@@ -2,8 +2,8 @@
 
 namespace AmplitudeExperiment\Remote;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
-use AmplitudeExperiment\Http\GuzzleFetchClient;
+use AmplitudeExperiment\Http\HttpClientInterface;
+use AmplitudeExperiment\Http\GuzzleHttpClient;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\User;
@@ -22,7 +22,7 @@ class RemoteEvaluationClient
 {
     private string $apiKey;
     private RemoteEvaluationConfig $config;
-    private FetchClientInterface $httpClient;
+    private HttpClientInterface $httpClient;
     private LoggerInterface $logger;
 
     /**
@@ -35,7 +35,7 @@ class RemoteEvaluationClient
     {
         $this->apiKey = $apiKey;
         $this->config = $config ?? RemoteEvaluationConfig::builder()->build();
-        $this->httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleFetchClient($this->config->guzzleClientConfig);
+        $this->httpClient = $config->fetchClient ?? $this->config->fetchClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
         $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
     }
 

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -2,7 +2,7 @@
 
 namespace AmplitudeExperiment\Remote;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\LogLevel;
 use Psr\Log\LoggerInterface;
@@ -30,12 +30,12 @@ class RemoteEvaluationConfig
      */
     public string $serverUrl;
     /**
-     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?FetchClientInterface $fetchClient;
+    public ?HttpClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default {@link GuzzleFetchClient} (if used). See {@link GUZZLE_DEFAULTS} for defaults.
+     * The configuration for the underlying default {@link GuzzleHttpClient} (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 
@@ -53,11 +53,11 @@ class RemoteEvaluationConfig
      * @param array<string, mixed> $guzzleClientConfig
      */
     public function __construct(
-        ?LoggerInterface      $logger,
-        int                   $logLevel,
-        string                $serverUrl,
-        ?FetchClientInterface $fetchClient,
-        array                 $guzzleClientConfig
+        ?LoggerInterface     $logger,
+        int                  $logLevel,
+        string               $serverUrl,
+        ?HttpClientInterface $fetchClient,
+        array                $guzzleClientConfig
     )
     {
         $this->logger = $logger;

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -11,7 +11,9 @@ use Psr\Log\LoggerInterface;
  * Configuration options. This is an object that can be created using
  * a {@link RemoteEvaluationConfigBuilder}. Example usage:
  *
- *`RemoteEvaluationConfig::builder()->serverUrl("https://api.lab.amplitude.com/")->build()`
+ *```
+ * RemoteEvaluationConfig::builder()->serverUrl("https://api.lab.amplitude.com/")->build();
+ * ```
  */
 class RemoteEvaluationConfig
 {
@@ -20,7 +22,7 @@ class RemoteEvaluationConfig
      */
     public ?LoggerInterface $logger;
     /**
-     * The log level to use for the logger.
+     * The {@link LogLevel} to use for the logger.
      */
     public int $logLevel;
     /**
@@ -28,12 +30,12 @@ class RemoteEvaluationConfig
      */
     public string $serverUrl;
     /**
-     * The underlying HTTP client to use for requests, if this is not set, the default GuzzleFetchClient will be used.
+     * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleFetchClient} will be used.
      */
     public ?FetchClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default Guzzle client. See {@link GUZZLE_DEFAULTS} for defaults.
+     * The configuration for the underlying default {@link GuzzleFetchClient} (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -33,7 +33,7 @@ class RemoteEvaluationConfig
     public ?FetchClientInterface $fetchClient;
     /**
      * @var array<string, mixed>
-     * The configuration for the underlying default Guzzle client.
+     * The configuration for the underlying default Guzzle client. See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
 

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -32,6 +32,7 @@ class RemoteEvaluationConfig
      */
     public ?FetchClientInterface $fetchClient;
     /**
+     * @var array<string, mixed>
      * The configuration for the underlying default Guzzle client.
      */
     public array $guzzleClientConfig;
@@ -46,6 +47,9 @@ class RemoteEvaluationConfig
     ];
 
 
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     */
     public function __construct(
         ?LoggerInterface      $logger,
         int                   $logLevel,

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -2,6 +2,11 @@
 
 namespace AmplitudeExperiment\Remote;
 
+use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Logger\DefaultLogger;
+use AmplitudeExperiment\Logger\LogLevel;
+use Psr\Log\LoggerInterface;
+
 /**
  * Configuration options. This is an object that can be created using
  * a {@link RemoteEvaluationConfigBuilder}. Example usage:
@@ -11,70 +16,49 @@ namespace AmplitudeExperiment\Remote;
 class RemoteEvaluationConfig
 {
     /**
-     * Set to true to log some extra information to the console.
+     * Set to use custom logger. If not set, a {@link DefaultLogger} is used.
      */
-    public bool $debug;
+    public ?LoggerInterface $logger;
+    /**
+     * The log level to use for the logger.
+     */
+    public int $logLevel;
     /**
      * The server endpoint from which to request variants.
      */
     public string $serverUrl;
     /**
-     * The request socket timeout, in milliseconds.
+     * The underlying HTTP client to use for requests.
      */
-    public int $fetchTimeoutMillis;
+    public ?FetchClientInterface $fetchClient;
     /**
-     * The number of retries to attempt before failing
+     * The configuration for the underlying default Guzzle client.
      */
-    public int $fetchRetries;
-    /**
-     * Retry backoff minimum (starting backoff delay) in milliseconds. The minimum backoff is scaled by
-     * `fetchRetryBackoffScalar` after each retry failure.
-     */
-    public int $fetchRetryBackoffMinMillis;
-    /**
-     * Retry backoff maximum in milliseconds. If the scaled backoff is greater than the max, the max is
-     * used for all subsequent retries.
-     */
-    public int $fetchRetryBackoffMaxMillis;
-    /**
-     * Scales the minimum backoff exponentially.
-     */
-    public float $fetchRetryBackoffScalar;
-    /**
-     * The request timeout for retrying fetch requests.
-     */
-    public int $fetchRetryTimeoutMillis;
+    public array $guzzleClientConfig;
 
     const DEFAULTS = [
+        'logger' => null,
+        'logLevel' => LogLevel::INFO,
         'debug' => false,
         'serverUrl' => 'https://api.lab.amplitude.com',
-        'fetchTimeoutMillis' => 10000,
-        'fetchRetries' => 8,
-        'fetchRetryBackoffMinMillis' => 500,
-        'fetchRetryBackoffMaxMillis' => 10000,
-        'fetchRetryBackoffScalar' => 1.5,
-        'fetchRetryTimeoutMillis' => 10000
+        'fetchClient' => null,
+        'guzzleClientConfig' => []
     ];
 
+
     public function __construct(
-        bool   $debug,
-        string $serverUrl,
-        int    $fetchTimeoutMillis,
-        int    $fetchRetries,
-        int    $fetchRetryBackoffMinMillis,
-        int    $fetchRetryBackoffMaxMillis,
-        float  $fetchRetryBackoffScalar,
-        int    $fetchRetryTimeoutMillis
+        ?LoggerInterface      $logger,
+        int                   $logLevel,
+        string                $serverUrl,
+        ?FetchClientInterface $fetchClient,
+        array                 $guzzleClientConfig
     )
     {
-        $this->debug = $debug;
+        $this->logger = $logger;
+        $this->logLevel = $logLevel;
         $this->serverUrl = $serverUrl;
-        $this->fetchTimeoutMillis = $fetchTimeoutMillis;
-        $this->fetchRetries = $fetchRetries;
-        $this->fetchRetryBackoffMinMillis = $fetchRetryBackoffMinMillis;
-        $this->fetchRetryBackoffMaxMillis = $fetchRetryBackoffMaxMillis;
-        $this->fetchRetryBackoffScalar = $fetchRetryBackoffScalar;
-        $this->fetchRetryTimeoutMillis = $fetchRetryTimeoutMillis;
+        $this->fetchClient = $fetchClient;
+        $this->guzzleClientConfig = $guzzleClientConfig;
     }
 
     public static function builder(): RemoteEvaluationConfigBuilder

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -41,7 +41,7 @@ class RemoteEvaluationConfig
 
     const DEFAULTS = [
         'logger' => null,
-        'logLevel' => LogLevel::INFO,
+        'logLevel' => LogLevel::ERROR,
         'debug' => false,
         'serverUrl' => 'https://api.lab.amplitude.com',
         'httpClient' => null,

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -32,7 +32,7 @@ class RemoteEvaluationConfig
     /**
      * The underlying HTTP client to use for requests, if this is not set, the default {@link GuzzleHttpClient} will be used.
      */
-    public ?HttpClientInterface $fetchClient;
+    public ?HttpClientInterface $httpClient;
     /**
      * @var array<string, mixed>
      * The configuration for the underlying default {@link GuzzleHttpClient} (if used). See {@link GUZZLE_DEFAULTS} for defaults.
@@ -44,7 +44,7 @@ class RemoteEvaluationConfig
         'logLevel' => LogLevel::INFO,
         'debug' => false,
         'serverUrl' => 'https://api.lab.amplitude.com',
-        'fetchClient' => null,
+        'httpClient' => null,
         'guzzleClientConfig' => []
     ];
 
@@ -56,14 +56,14 @@ class RemoteEvaluationConfig
         ?LoggerInterface     $logger,
         int                  $logLevel,
         string               $serverUrl,
-        ?HttpClientInterface $fetchClient,
+        ?HttpClientInterface $httpClient,
         array                $guzzleClientConfig
     )
     {
         $this->logger = $logger;
         $this->logLevel = $logLevel;
         $this->serverUrl = $serverUrl;
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         $this->guzzleClientConfig = $guzzleClientConfig;
     }
 

--- a/src/Remote/RemoteEvaluationConfig.php
+++ b/src/Remote/RemoteEvaluationConfig.php
@@ -28,7 +28,7 @@ class RemoteEvaluationConfig
      */
     public string $serverUrl;
     /**
-     * The underlying HTTP client to use for requests.
+     * The underlying HTTP client to use for requests, if this is not set, the default GuzzleFetchClient will be used.
      */
     public ?FetchClientInterface $fetchClient;
     /**

--- a/src/Remote/RemoteEvaluationConfigBuilder.php
+++ b/src/Remote/RemoteEvaluationConfigBuilder.php
@@ -12,7 +12,7 @@ class RemoteEvaluationConfigBuilder
     protected int $logLevel = RemoteEvaluationConfig::DEFAULTS['logLevel'];
     protected bool $debug = RemoteEvaluationConfig::DEFAULTS['debug'];
     protected string $serverUrl = RemoteEvaluationConfig::DEFAULTS['serverUrl'];
-    protected ?HttpClientInterface $fetchClient = RemoteEvaluationConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $httpClient = RemoteEvaluationConfig::DEFAULTS['httpClient'];
     /**
      * @var array<string, mixed>
      */
@@ -40,9 +40,9 @@ class RemoteEvaluationConfigBuilder
         return $this;
     }
 
-    public function fetchClient(HttpClientInterface $fetchClient): RemoteEvaluationConfigBuilder
+    public function httpClient(HttpClientInterface $httpClient): RemoteEvaluationConfigBuilder
     {
-        $this->fetchClient = $fetchClient;
+        $this->httpClient = $httpClient;
         return $this;
     }
 
@@ -62,7 +62,7 @@ class RemoteEvaluationConfigBuilder
             $this->logger,
             $this->logLevel,
             $this->serverUrl,
-            $this->fetchClient,
+            $this->httpClient,
             $this->guzzleClientConfig
         );
     }

--- a/src/Remote/RemoteEvaluationConfigBuilder.php
+++ b/src/Remote/RemoteEvaluationConfigBuilder.php
@@ -4,7 +4,6 @@ namespace AmplitudeExperiment\Remote;
 
 use AmplitudeExperiment\Http\HttpClientInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 class RemoteEvaluationConfigBuilder
 {

--- a/src/Remote/RemoteEvaluationConfigBuilder.php
+++ b/src/Remote/RemoteEvaluationConfigBuilder.php
@@ -2,7 +2,7 @@
 
 namespace AmplitudeExperiment\Remote;
 
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -12,7 +12,7 @@ class RemoteEvaluationConfigBuilder
     protected int $logLevel = RemoteEvaluationConfig::DEFAULTS['logLevel'];
     protected bool $debug = RemoteEvaluationConfig::DEFAULTS['debug'];
     protected string $serverUrl = RemoteEvaluationConfig::DEFAULTS['serverUrl'];
-    protected ?FetchClientInterface $fetchClient = RemoteEvaluationConfig::DEFAULTS['fetchClient'];
+    protected ?HttpClientInterface $fetchClient = RemoteEvaluationConfig::DEFAULTS['fetchClient'];
     /**
      * @var array<string, mixed>
      */
@@ -40,7 +40,7 @@ class RemoteEvaluationConfigBuilder
         return $this;
     }
 
-    public function fetchClient(FetchClientInterface $fetchClient): RemoteEvaluationConfigBuilder
+    public function fetchClient(HttpClientInterface $fetchClient): RemoteEvaluationConfigBuilder
     {
         $this->fetchClient = $fetchClient;
         return $this;

--- a/src/Remote/RemoteEvaluationConfigBuilder.php
+++ b/src/Remote/RemoteEvaluationConfigBuilder.php
@@ -13,6 +13,9 @@ class RemoteEvaluationConfigBuilder
     protected bool $debug = RemoteEvaluationConfig::DEFAULTS['debug'];
     protected string $serverUrl = RemoteEvaluationConfig::DEFAULTS['serverUrl'];
     protected ?FetchClientInterface $fetchClient = RemoteEvaluationConfig::DEFAULTS['fetchClient'];
+    /**
+     * @var array<string, mixed>
+     */
     protected array $guzzleClientConfig = RemoteEvaluationConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
@@ -43,6 +46,10 @@ class RemoteEvaluationConfigBuilder
         return $this;
     }
 
+
+    /**
+     * @param array<string, mixed> $guzzleClientConfig
+     */
     public function guzzleClientConfig(array $guzzleClientConfig): RemoteEvaluationConfigBuilder
     {
         $this->guzzleClientConfig = $guzzleClientConfig;

--- a/src/Remote/RemoteEvaluationConfigBuilder.php
+++ b/src/Remote/RemoteEvaluationConfigBuilder.php
@@ -2,24 +2,32 @@
 
 namespace AmplitudeExperiment\Remote;
 
+use AmplitudeExperiment\Http\FetchClientInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
 class RemoteEvaluationConfigBuilder
 {
+    protected ?LoggerInterface $logger = RemoteEvaluationConfig::DEFAULTS['logger'];
+    protected int $logLevel = RemoteEvaluationConfig::DEFAULTS['logLevel'];
     protected bool $debug = RemoteEvaluationConfig::DEFAULTS['debug'];
     protected string $serverUrl = RemoteEvaluationConfig::DEFAULTS['serverUrl'];
-    protected int $fetchTimeoutMillis = RemoteEvaluationConfig::DEFAULTS['fetchTimeoutMillis'];
-    protected int $fetchRetries = RemoteEvaluationConfig::DEFAULTS['fetchRetries'];
-    protected int $fetchRetryBackoffMinMillis = RemoteEvaluationConfig::DEFAULTS['fetchRetryBackoffMinMillis'];
-    protected int $fetchRetryBackoffMaxMillis = RemoteEvaluationConfig::DEFAULTS['fetchRetryBackoffMaxMillis'];
-    protected float $fetchRetryBackoffScalar = RemoteEvaluationConfig::DEFAULTS['fetchRetryBackoffScalar'];
-    protected int $fetchRetryTimeoutMillis = RemoteEvaluationConfig::DEFAULTS['fetchRetryTimeoutMillis'];
+    protected ?FetchClientInterface $fetchClient = RemoteEvaluationConfig::DEFAULTS['fetchClient'];
+    protected array $guzzleClientConfig = RemoteEvaluationConfig::DEFAULTS['guzzleClientConfig'];
 
     public function __construct()
     {
     }
 
-    public function debug(bool $debug): RemoteEvaluationConfigBuilder
+    public function logger(LoggerInterface $logger): RemoteEvaluationConfigBuilder
     {
-        $this->debug = $debug;
+        $this->logger = $logger;
+        return $this;
+    }
+
+    public function logLevel(int $logLevel): RemoteEvaluationConfigBuilder
+    {
+        $this->logLevel = $logLevel;
         return $this;
     }
 
@@ -29,53 +37,26 @@ class RemoteEvaluationConfigBuilder
         return $this;
     }
 
-    public function fetchTimeoutMillis(int $fetchTimeoutMillis): RemoteEvaluationConfigBuilder
+    public function fetchClient(FetchClientInterface $fetchClient): RemoteEvaluationConfigBuilder
     {
-        $this->fetchTimeoutMillis = $fetchTimeoutMillis;
+        $this->fetchClient = $fetchClient;
         return $this;
     }
 
-    public function fetchRetries(int $fetchRetries): RemoteEvaluationConfigBuilder
+    public function guzzleClientConfig(array $guzzleClientConfig): RemoteEvaluationConfigBuilder
     {
-        $this->fetchRetries = $fetchRetries;
-        return $this;
-    }
-
-    public function fetchRetryBackoffMinMillis(int $fetchRetryBackoffMinMillis): RemoteEvaluationConfigBuilder
-    {
-        $this->fetchRetryBackoffMinMillis = $fetchRetryBackoffMinMillis;
-        return $this;
-    }
-
-    public function fetchRetryBackoffMaxMillis(int $fetchRetryBackoffMaxMillis): RemoteEvaluationConfigBuilder
-    {
-        $this->fetchRetryBackoffMaxMillis = $fetchRetryBackoffMaxMillis;
-        return $this;
-    }
-
-    public function fetchRetryBackoffScalar(float $fetchRetryBackoffScalar): RemoteEvaluationConfigBuilder
-    {
-        $this->fetchRetryBackoffScalar = $fetchRetryBackoffScalar;
-        return $this;
-    }
-
-    public function fetchRetryTimeoutMillis(int $fetchRetryTimeoutMillis): RemoteEvaluationConfigBuilder
-    {
-        $this->fetchRetryTimeoutMillis = $fetchRetryTimeoutMillis;
+        $this->guzzleClientConfig = $guzzleClientConfig;
         return $this;
     }
 
     public function build(): RemoteEvaluationConfig
     {
         return new RemoteEvaluationConfig(
-            $this->debug,
+            $this->logger,
+            $this->logLevel,
             $this->serverUrl,
-            $this->fetchTimeoutMillis,
-            $this->fetchRetries,
-            $this->fetchRetryBackoffMinMillis,
-            $this->fetchRetryBackoffMaxMillis,
-            $this->fetchRetryBackoffScalar,
-            $this->fetchRetryTimeoutMillis,
+            $this->fetchClient,
+            $this->guzzleClientConfig
         );
     }
 }

--- a/src/User.php
+++ b/src/User.php
@@ -38,10 +38,24 @@ class User
     public ?string $deviceModel;
     public ?string $carrier;
     public ?string $library;
+    /**
+     * @var ?array<mixed>
+     */
     public ?array $userProperties;
+    /**
+     * @var ?array<mixed>
+     */
     public ?array $groups;
+    /**
+     * @var ?array<mixed>
+     */
     public ?array $groupProperties;
 
+    /**
+     * @param ?array<mixed> $userProperties
+     * @param ?array<mixed> $groups
+     * @param ?array<mixed> $groupProperties
+     */
     public function __construct(
         ?string $deviceId,
         ?string $userId,
@@ -109,6 +123,9 @@ class User
             ->groupProperties($this->groupProperties);
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function toArray(): array {
         return array_filter(["device_id" => $this->deviceId,
             "user_id" => $this->userId,
@@ -130,6 +147,9 @@ class User
             "group_properties" => $this->groupProperties]);
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function toEvaluationContext(): array
     {
 

--- a/src/UserBuilder.php
+++ b/src/UserBuilder.php
@@ -19,8 +19,17 @@ class UserBuilder
     protected ?string $deviceModel = null;
     protected ?string $carrier = null;
     protected ?string $library = null;
+    /**
+     * @var ?array<mixed>
+     */
     protected ?array $userProperties = null;
+    /**
+     * @var ?array<mixed>
+     */
     protected ?array $groups = null;
+    /**
+     * @var ?array<mixed>
+     */
     protected ?array $groupProperties = null;
 
     public function __construct()
@@ -117,18 +126,27 @@ class UserBuilder
         return $this;
     }
 
+    /**
+     * @param ?array<mixed> $userProperties
+     */
     public function userProperties(?array $userProperties): UserBuilder
     {
         $this->userProperties = $userProperties;
         return $this;
     }
 
+    /**
+     * @param ?array<mixed> $groups
+     */
     public function groups(?array $groups): UserBuilder
     {
         $this->groups = $groups;
         return $this;
     }
 
+    /**
+     * @param ?array<mixed> $groupProperties
+     */
     public function groupProperties(?array $groupProperties): UserBuilder
     {
         $this->groupProperties = $groupProperties;

--- a/src/Util.php
+++ b/src/Util.php
@@ -2,20 +2,6 @@
 
 namespace AmplitudeExperiment;
 
-use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
-
-function initializeLogger(bool $debug): Logger
-{
-    $logger = new Logger('AmplitudeExperiment');
-    $handler = new StreamHandler('php://stdout', $debug ? Logger::DEBUG : Logger::INFO);
-    $formatter = new LineFormatter(null, null, false, true);
-    $handler->setFormatter($formatter);
-    $logger->pushHandler($handler);
-    return $logger;
-}
-
 function hashCode(string $s): int
 {
     $hash = 0;

--- a/src/Util.php
+++ b/src/Util.php
@@ -10,8 +10,7 @@ function hashCode(string $s): int
     }
     for ($i = 0; $i < strlen($s); $i++) {
         $chr = ord($s[$i]);
-        $hash = ($hash << 5) - $hash + $chr;
-        $hash |= 0;
+        $hash = (int) (($hash << 5) - $hash + $chr);
     }
     return $hash;
 }

--- a/src/Variant.php
+++ b/src/Variant.php
@@ -13,6 +13,7 @@ class Variant
      */
     public ?string $value;
     /**
+     * @var mixed
      * The attached payload, if any
      */
     public $payload;
@@ -21,11 +22,16 @@ class Variant
      */
     public ?string $expKey;
     /**
+     * @var ?array<mixed>
      * Flag, segment, and variant metadata produced as a result of
      * evaluation for the user. Used for system purposes.
      */
     public ?array $metadata;
 
+    /**
+     * @param mixed $payload
+     * @param ?array<mixed> $metadata
+     */
     public function __construct(
         ?string $key = null,
         ?string $value = null,
@@ -41,6 +47,9 @@ class Variant
         $this->metadata = $metadata;
     }
 
+    /**
+     * @param array<mixed> $evaluationVariant
+     */
     public static function convertEvaluationVariantToVariant(array $evaluationVariant): Variant
     {
 

--- a/tests/Amplitude/AmplitudeTest.php
+++ b/tests/Amplitude/AmplitudeTest.php
@@ -7,7 +7,7 @@ use AmplitudeExperiment\Amplitude\Event;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\Logger\LogLevel;
-use AmplitudeExperiment\Test\Util\MockGuzzleFetchClient;
+use AmplitudeExperiment\Test\Util\MockGuzzleHttpClient;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -58,7 +58,7 @@ class AmplitudeTest extends TestCase
             new Response(200, ['X-Foo' => 'Bar']),
         ]);
         $handlerStack = HandlerStack::create($mock);
-        $httpClient = new MockGuzzleFetchClient([], $handlerStack);
+        $httpClient = new MockGuzzleHttpClient([], $handlerStack);
         $client->setHttpClient($httpClient);
         $event1 = new Event('test1');
         $event2 = new Event('test2');
@@ -92,7 +92,7 @@ class AmplitudeTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleFetchClient([], $handlerStack);
+        $fetchClient = new MockGuzzleHttpClient([], $handlerStack);
         $client->setHttpClient($fetchClient);
         $event1 = new Event('test1');
         $event2 = new Event('test2');
@@ -119,7 +119,7 @@ class AmplitudeTest extends TestCase
         }));
 
         $handlerStack = HandlerStack::create($mockHandler);
-        $httpClient = new MockGuzzleFetchClient(['fetchRetries' => 4], $handlerStack);
+        $httpClient = new MockGuzzleHttpClient(['retries' => 4], $handlerStack);
         $client->setHttpClient($httpClient);
 
         $event1 = new Event('test');
@@ -153,7 +153,7 @@ class AmplitudeTest extends TestCase
             ]);
 
         $handlerStack = HandlerStack::create($mockHandler);
-        $httpClient = new MockGuzzleFetchClient(['fetchRetries' => 4], $handlerStack);
+        $httpClient = new MockGuzzleHttpClient(['retries' => 4], $handlerStack);
         $client->setHttpClient($httpClient);
         $event1 = new Event('test');
         $event1->userId = 'user_id';

--- a/tests/Amplitude/AmplitudeTest.php
+++ b/tests/Amplitude/AmplitudeTest.php
@@ -92,8 +92,8 @@ class AmplitudeTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleHttpClient([], $handlerStack);
-        $client->setHttpClient($fetchClient);
+        $httpClient = new MockGuzzleHttpClient([], $handlerStack);
+        $client->setHttpClient($httpClient);
         $event1 = new Event('test1');
         $event2 = new Event('test2');
         $event3 = new Event('test3');

--- a/tests/Amplitude/MockAmplitude.php
+++ b/tests/Amplitude/MockAmplitude.php
@@ -4,7 +4,7 @@ namespace AmplitudeExperiment\Test\Amplitude;
 
 use AmplitudeExperiment\Amplitude\Amplitude;
 use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-use AmplitudeExperiment\Http\FetchClientInterface;
+use AmplitudeExperiment\Http\HttpClientInterface;
 use Psr\Log\LoggerInterface;
 
 class MockAmplitude extends Amplitude
@@ -13,7 +13,7 @@ class MockAmplitude extends Amplitude
     {
         parent::__construct($apiKey, $logger, $config);
     }
-    public function setHttpClient(FetchClientInterface $httpClient) {
+    public function setHttpClient(HttpClientInterface $httpClient) {
         $this->httpClient = $httpClient;
     }
     public function __destruct() {

--- a/tests/Amplitude/MockAmplitude.php
+++ b/tests/Amplitude/MockAmplitude.php
@@ -4,16 +4,20 @@ namespace AmplitudeExperiment\Test\Amplitude;
 
 use AmplitudeExperiment\Amplitude\Amplitude;
 use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-use GuzzleHttp\Client;
+use AmplitudeExperiment\Http\FetchClientInterface;
+use Psr\Log\LoggerInterface;
 
 class MockAmplitude extends Amplitude
 {
-    public function __construct(string $apiKey, bool $debug, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, LoggerInterface $logger, AmplitudeConfig $config = null)
     {
-        parent::__construct($apiKey, $debug, $config);
+        parent::__construct($apiKey, $logger, $config);
     }
-    public function setHttpClient(Client $httpClient) {
+    public function setHttpClient(FetchClientInterface $httpClient) {
         $this->httpClient = $httpClient;
+    }
+    public function __destruct() {
+        // Do nothing
     }
     public function getQueueSize() : int {
         return count($this->queue);

--- a/tests/Assignment/AssignmentFilterTest.php
+++ b/tests/Assignment/AssignmentFilterTest.php
@@ -7,7 +7,6 @@ use AmplitudeExperiment\Assignment\AssignmentFilter;
 use AmplitudeExperiment\User;
 use AmplitudeExperiment\Variant;
 use PHPUnit\Framework\TestCase;
-use function AmplitudeExperiment\sleep;
 
 require_once __DIR__ . '/../../src/Util.php';
 
@@ -149,7 +148,7 @@ class AssignmentFilterTest extends TestCase
         $assignment1 = new Assignment($user1, $results);
         $assignment2 = new Assignment($user2, $results);
         $this->assertTrue($filter->shouldTrack($assignment1));
-        \sleep(1.05);
+        sleep(1);
         $this->assertTrue($filter->shouldTrack($assignment2));
     }
 }

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -6,6 +6,9 @@ use AmplitudeExperiment\Amplitude\Amplitude;
 use AmplitudeExperiment\Assignment\Assignment;
 use AmplitudeExperiment\Assignment\AssignmentFilter;
 use AmplitudeExperiment\Assignment\AssignmentService;
+use AmplitudeExperiment\Logger\DefaultLogger;
+use AmplitudeExperiment\Logger\InternalLogger;
+use AmplitudeExperiment\Logger\LogLevel;
 use AmplitudeExperiment\User;
 use AmplitudeExperiment\Variant;
 use PHPUnit\Framework\TestCase;
@@ -82,10 +85,11 @@ class AssignmentServiceTest extends TestCase
         $this->assertEquals($expected, $event->insertId);
     }
 
-    public function testlogEventCalledInAmplitude() {
+    public function testlogEventCalledInAmplitude()
+    {
         $assignmentFilter = new AssignmentFilter(1);
         $mockAmp = $this->getMockBuilder(Amplitude::class)
-            ->setConstructorArgs(['', false])
+            ->setConstructorArgs(['', new InternalLogger(new DefaultLogger(), LogLevel::INFO)])
             ->onlyMethods(['logEvent'])
             ->getMock();
         $results = [

--- a/tests/EvaluationCore/Murmur3Test.php
+++ b/tests/EvaluationCore/Murmur3Test.php
@@ -2,6 +2,7 @@
 
 namespace AmplitudeExperiment\Test\EvaluationCore;
 
+use AmplitudeExperiment\EvaluationCore\Murmur3;
 use PHPUnit\Framework\TestCase;
 
 class Murmur3Test extends TestCase
@@ -11,7 +12,7 @@ class Murmur3Test extends TestCase
     public function testMurmur3HashSimple()
     {
         $input = 'brian';
-        $result = murmurhash3_int($input, self::MURMUR_SEED);
+        $result = Murmur3::hash3_int($input, self::MURMUR_SEED);
         $this->assertEquals(3948467465, $result);
     }
 
@@ -23,16 +24,16 @@ class Murmur3Test extends TestCase
         for ($i = 0; $i < count($inputs); $i++) {
             $input = $inputs[$i];
             $output = (int)$outputs[$i];
-            $result = murmurhash3_int($input, self::MURMUR_SEED);
+            $result = Murmur3::hash3_int($input, self::MURMUR_SEED);
             $this->assertEquals($output, $result);
         }
     }
 
     public function testUnicodeStrings()
     {
-        $this->assertEquals(2953494853, murmurhash3_int('My hovercraft is full of eels.'));
-        $this->assertEquals(1818098979, murmurhash3_int('My 🚀 is full of 🦎.'));
-        $this->assertEquals(3435142074, murmurhash3_int('吉 星 高 照'));
+        $this->assertEquals(2953494853, Murmur3::hash3_int('My hovercraft is full of eels.'));
+        $this->assertEquals(1818098979, Murmur3::hash3_int('My 🚀 is full of 🦎.'));
+        $this->assertEquals(3435142074, Murmur3::hash3_int('吉 星 高 照'));
     }
 
     const MURMUR3_X86_32 = '

--- a/tests/Local/LocalEvaluationClientTest.php
+++ b/tests/Local/LocalEvaluationClientTest.php
@@ -5,6 +5,7 @@ namespace AmplitudeExperiment\Test\Local;
 use AmplitudeExperiment\Experiment;
 use AmplitudeExperiment\Local\LocalEvaluationClient;
 use AmplitudeExperiment\Local\LocalEvaluationConfig;
+use AmplitudeExperiment\Logger\LogLevel;
 use AmplitudeExperiment\User;
 use PHPUnit\Framework\TestCase;
 
@@ -22,13 +23,13 @@ class LocalEvaluationClientTest extends TestCase
             ->deviceId('test_device')
             ->build();
         $experiment = new Experiment();
-        $config = LocalEvaluationConfig::builder()->debug(true)->build();
+        $config = LocalEvaluationConfig::builder()->logLevel(LogLevel::DEBUG)->build();
         $this->client = $experiment->initializeLocal($this->apiKey, $config);
     }
 
     public function setUp(): void
     {
-        $this->client->start()->wait();
+        $this->client->start();
     }
 
     public function testEvaluateAllFlags()

--- a/tests/Local/LocalEvaluationClientTest.php
+++ b/tests/Local/LocalEvaluationClientTest.php
@@ -29,7 +29,7 @@ class LocalEvaluationClientTest extends TestCase
 
     public function setUp(): void
     {
-        $this->client->start();
+        $this->client->refreshFlagConfigs();
     }
 
     public function testEvaluateAllFlags()
@@ -69,5 +69,15 @@ class LocalEvaluationClientTest extends TestCase
         $this->assertEquals("off", $variant->key);
         $this->assertEquals(null, $variant->payload);
         $this->assertTrue($variant->metadata["default"]);
+    }
+
+    public function testGetFlagConfigs()
+    {
+        $flagConfigs = $this->client->getFlagConfigs();
+        $bootstrapClient = new LocalEvaluationClient('', LocalEvaluationConfig::builder()->bootstrap($flagConfigs)->build());
+        $variants = $bootstrapClient->evaluate($this->testUser);
+        $variant = $variants['sdk-local-evaluation-ci-test'];
+        $this->assertEquals("on", $variant->key);
+        $this->assertEquals("payload", $variant->payload);
     }
 }

--- a/tests/Remote/RemoteEvaluationClientTest.php
+++ b/tests/Remote/RemoteEvaluationClientTest.php
@@ -72,7 +72,7 @@ class RemoteEvaluationClientTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleHttpClient([
+        $httpClient = new MockGuzzleHttpClient([
             'retries' => 1,
             'timeoutMillis' => 10000,
             'retryBackoffMinMillis' => 100,
@@ -80,7 +80,7 @@ class RemoteEvaluationClientTest extends TestCase
             'retryBackoffMaxMillis' => 500,
         ], $handlerStack);
 
-        $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->fetchClient($fetchClient)->build());
+        $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->httpClient($httpClient)->build());
 
         // Expect a successful response after auto-retry
         $variants = $client->fetch($this->testUser);
@@ -117,7 +117,7 @@ class RemoteEvaluationClientTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleHttpClient([
+        $httpClient = new MockGuzzleHttpClient([
             'retries' => 1,
             'timeoutMillis' => 10000,
             'retryBackoffMinMillis' => 0,
@@ -125,7 +125,7 @@ class RemoteEvaluationClientTest extends TestCase
             'retryBackoffMaxMillis' => 0,
         ], $handlerStack);
 
-        $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->fetchClient($fetchClient)->build());
+        $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->httpClient($httpClient)->build());
 
         // Expect a successful response after auto-retry
         $variants = $client->fetch($this->testUser);

--- a/tests/Remote/RemoteEvaluationClientTest.php
+++ b/tests/Remote/RemoteEvaluationClientTest.php
@@ -5,7 +5,7 @@ namespace AmplitudeExperiment\Test\Remote;
 use AmplitudeExperiment\Experiment;
 use AmplitudeExperiment\Remote\RemoteEvaluationClient;
 use AmplitudeExperiment\Remote\RemoteEvaluationConfig;
-use AmplitudeExperiment\Test\Util\MockGuzzleFetchClient;
+use AmplitudeExperiment\Test\Util\MockGuzzleHttpClient;
 use AmplitudeExperiment\User;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
@@ -38,7 +38,7 @@ class RemoteEvaluationClientTest extends TestCase
 
     public function testFetchWithNoRetriesTimeoutFailure()
     {
-        $guzzleConfig = ['fetchRetries' => 0, 'fetchTimeoutMillis' => 1];
+        $guzzleConfig = ['retries' => 0, 'timeoutMillis' => 1];
         $config = RemoteEvaluationConfig::builder()
             ->guzzleClientConfig($guzzleConfig)
             ->build();
@@ -72,12 +72,12 @@ class RemoteEvaluationClientTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleFetchClient([
-            'fetchRetries' => 1,
-            'fetchTimeoutMillis' => 10000,
-            'fetchRetryBackoffMinMillis' => 100,
-            'fetchRetryBackoffScalar' => 2,
-            'fetchRetryBackoffMaxMillis' => 500,
+        $fetchClient = new MockGuzzleHttpClient([
+            'retries' => 1,
+            'timeoutMillis' => 10000,
+            'retryBackoffMinMillis' => 100,
+            'retryBackoffScalar' => 2,
+            'retryBackoffMaxMillis' => 500,
         ], $handlerStack);
 
         $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->fetchClient($fetchClient)->build());
@@ -92,7 +92,7 @@ class RemoteEvaluationClientTest extends TestCase
         $this->assertEquals(2, $requestCounter);
     }
 
-    public function testFetchRetryOnceTimeoutFirstThenSucceedWithZeroBackoff()
+    public function testretryOnceTimeoutFirstThenSucceedWithZeroBackoff()
     {
         // Initialize the request counter
         $requestCounter = 0;
@@ -117,12 +117,12 @@ class RemoteEvaluationClientTest extends TestCase
         $handlerStack = HandlerStack::create($mockHandler);
 
         // Create an instance of GuzzleFetchClient with the custom handler stack
-        $fetchClient = new MockGuzzleFetchClient([
-            'fetchRetries' => 1,
-            'fetchTimeoutMillis' => 10000,
-            'fetchRetryBackoffMinMillis' => 0,
-            'fetchRetryBackoffScalar' => 2,
-            'fetchRetryBackoffMaxMillis' => 0,
+        $fetchClient = new MockGuzzleHttpClient([
+            'retries' => 1,
+            'timeoutMillis' => 10000,
+            'retryBackoffMinMillis' => 0,
+            'retryBackoffScalar' => 2,
+            'retryBackoffMaxMillis' => 0,
         ], $handlerStack);
 
         $client = new RemoteEvaluationClient($this->apiKey, RemoteEvaluationConfig::builder()->fetchClient($fetchClient)->build());

--- a/tests/Util/MockGuzzleFetchClient.php
+++ b/tests/Util/MockGuzzleFetchClient.php
@@ -42,7 +42,7 @@ class MockGuzzleFetchClient implements FetchClientInterface
         return $this->client;
     }
 
-    public function createRequest(string $method, string $uri): Request
+    public function createRequest(string $method, string $uri, ?string $body = null): Request
     {
         return new Request($method, $uri);
     }

--- a/tests/Util/MockGuzzleFetchClient.php
+++ b/tests/Util/MockGuzzleFetchClient.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AmplitudeExperiment\Test\Util;
+
+use AmplitudeExperiment\Http\FetchClientInterface;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\RequestOptions;
+use Psr\Http\Client\ClientInterface;
+use const AmplitudeExperiment\Http\GUZZLE_DEFAULTS;
+
+class MockGuzzleFetchClient implements FetchClientInterface
+{
+    private Client $client;
+    private array $config;
+
+    public function __construct(array $config, HandlerStack $handlerStack)
+    {
+        $this->config = array_merge(GUZZLE_DEFAULTS, $config);
+
+        // Add middleware for retries
+        $handlerStack->push(Middleware::retry(
+            function ($retries, Request $request, $response = null, $exception = null) {
+                // Retry if the maximum number of retries is not reached and an exception occurred
+                return $retries < $this->config['fetchRetries'] && $exception instanceof Exception;
+            },
+            function ($retries) {
+                // Calculate delay
+                return $this->calculateDelayMillis($retries);
+            }
+        ));
+
+        // Create a Guzzle client with the custom handler stack
+        $this->client = new Client(['handler' => $handlerStack, RequestOptions::TIMEOUT => $this->config['fetchTimeoutMillis'] / 1000]);
+    }
+
+    public function getClient(): ClientInterface
+    {
+        return $this->client;
+    }
+
+    public function createRequest(string $method, string $uri): Request
+    {
+        return new Request($method, $uri);
+    }
+
+    protected function calculateDelayMillis($iteration): int
+    {
+        $delayMillis = $this->config['fetchRetryBackoffMinMillis'];
+
+        for ($i = 0; $i < $iteration; $i++) {
+            $delayMillis = min(
+                $delayMillis * $this->config['fetchRetryBackoffScalar'],
+                $this->config['fetchRetryBackoffMaxMillis']
+            );
+        }
+        return $delayMillis;
+    }
+}


### PR DESCRIPTION
Implementation of suggested [enhancements](https://github.com/amplitude/experiment-php-server/issues/10).

Updates to support:
- Custom HTTP Client and Logger - set in `RemoteEvaluationConfig`, `LocalEvaluationConfig`, `AssignmentConfig`
    - HTTP Client (using interface instead of `php-http/discovery` for more flexibility)
        - Set via the `httpClient` property
        - The custom client will implement the [`HttpClientInterface`](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-980b6585d3262556802683bee542a7655f065ff9afe708328039a903224801e5)
        - If a custom client is not provided, a [default](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-1b338d7ac84e8d629751b0b9bf1e87f79bc70a92778a9d8b5490afa4bced4d2d) `Guzzle`-based client is used
            - The default client can be set via the `guzzleClientConfig` property
    - PSR Logger
        - Set via the`logger` property
        - The [log level](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-efbdf640653f46cd2ff2360420a07da601d20e7359578650bec1cd7bd23fb3b8) is set via `logLevel` property
        - If a custom logger is not provided, a [default](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-1932487e74c2a7852bef5e485370c586db531b82275874fbdb579c54f306e05d) `error_log`-based logger is used
- Internal implementation of MurmurHash3
- Improved testing to use [PHPStan](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766); test additional PHP [versions](https://github.com/amplitude/experiment-php-server/pull/13/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14)
    - Majority of files changed are due to PHPStan style suggestions and not change in implementation