### PR TITLE
feat: AssignmentTrackingProvider used to track local evaluation assignment events

### DIFF
--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -4,6 +4,8 @@ namespace AmplitudeExperiment\Amplitude;
 
 use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Http\GuzzleHttpClient;
+use AmplitudeExperiment\Logger\DefaultLogger;
+use AmplitudeExperiment\Logger\InternalLogger;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 
@@ -21,11 +23,11 @@ class Amplitude
     private LoggerInterface $logger;
     private AmplitudeConfig $config;
 
-    public function __construct(string $apiKey, LoggerInterface $logger, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, AmplitudeConfig $config = null)
     {
         $this->apiKey = $apiKey;
-        $this->logger = $logger;
         $this->config = $config ?? AmplitudeConfig::builder()->build();
+        $this->logger = new InternalLogger($this->config->logger ?? new DefaultLogger(), $this->config->logLevel);
         $this->httpClient = $this->config->httpClient ?? $this->config->httpClient ?? new GuzzleHttpClient($this->config->guzzleClientConfig);
     }
 

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -2,8 +2,6 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
-use AmplitudeExperiment\Assignment\Assignment;
-use AmplitudeExperiment\Assignment\AssignmentService;
 use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Http\GuzzleHttpClient;
 use AmplitudeExperiment\Logger\DefaultLogger;

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -2,6 +2,8 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+use AmplitudeExperiment\Assignment\Assignment;
+use AmplitudeExperiment\Assignment\AssignmentService;
 use AmplitudeExperiment\Http\HttpClientInterface;
 use AmplitudeExperiment\Http\GuzzleHttpClient;
 use AmplitudeExperiment\Logger\DefaultLogger;
@@ -14,6 +16,9 @@ use Psr\Log\LoggerInterface;
  */
 class Amplitude
 {
+    /**
+     * The Amplitude Project API key.
+     */
     private string $apiKey;
     /**
      * @var array<array<string,mixed>>
@@ -39,7 +44,7 @@ class Amplitude
 
     public function logEvent(Event $event): void
     {
-        $this->queue[] = $event->toArray();
+        $this->queue[] =  $event->toArray();
         if (count($this->queue) >= $this->config->flushQueueSize) {
             $this->flush();
         }

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -44,7 +44,7 @@ class Amplitude
 
     public function logEvent(Event $event): void
     {
-        $this->queue[] =  $event->toArray();
+        $this->queue[] = $event->toArray();
         if (count($this->queue) >= $this->config->flushQueueSize) {
             $this->flush();
         }

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -5,6 +5,8 @@ namespace AmplitudeExperiment\Amplitude;
 use AmplitudeExperiment\Assignment\AssignmentConfig;
 use AmplitudeExperiment\Assignment\AssignmentConfigBuilder;
 use AmplitudeExperiment\Http\HttpClientInterface;
+use AmplitudeExperiment\Logger\LogLevel;
+use Psr\Log\LoggerInterface;
 
 /**
  * Configuration options for Amplitude. The Amplitude object is created when you create an {@link AssignmentConfig}.
@@ -42,6 +44,14 @@ class AmplitudeConfig
      * The configuration for the underlying default {@link GuzzleHttpClient} client (if used). See {@link GUZZLE_DEFAULTS} for defaults.
      */
     public array $guzzleClientConfig;
+    /**
+     * Set to use custom logger. If not set, a {@link DefaultLogger} is used.
+     */
+    public ?LoggerInterface $logger;
+    /**
+     * The {@link LogLevel} to use for the logger.
+     */
+    public int $logLevel;
 
     const DEFAULTS = [
         'serverZone' => 'US',
@@ -60,7 +70,9 @@ class AmplitudeConfig
         'flushQueueSize' => 200,
         'flushMaxRetries' => 12,
         'httpClient' => null,
-        'guzzleClientConfig' => []
+        'guzzleClientConfig' => [],
+        'logger' => null,
+        'logLevel' => LogLevel::ERROR,
     ];
 
     /**
@@ -73,8 +85,9 @@ class AmplitudeConfig
         string               $serverUrl,
         bool                 $useBatch,
         ?HttpClientInterface $httpClient,
-        array                $guzzleClientConfig
-    )
+        array                $guzzleClientConfig,
+        ?LoggerInterface      $logger,
+        int                  $logLevel)
     {
         $this->flushQueueSize = $flushQueueSize;
         $this->minIdLength = $minIdLength;
@@ -83,6 +96,8 @@ class AmplitudeConfig
         $this->useBatch = $useBatch;
         $this->httpClient = $httpClient;
         $this->guzzleClientConfig = $guzzleClientConfig;
+        $this->logger = $logger;
+        $this->logLevel = $logLevel;
     }
 
     public static function builder(): AmplitudeConfigBuilder

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -68,7 +68,6 @@ class AmplitudeConfig
         'useBatch' => false,
         'minIdLength' => 5,
         'flushQueueSize' => 200,
-        'flushMaxRetries' => 12,
         'httpClient' => null,
         'guzzleClientConfig' => [],
         'logger' => null,

--- a/src/Amplitude/AmplitudeConfig.php
+++ b/src/Amplitude/AmplitudeConfig.php
@@ -20,7 +20,7 @@ class AmplitudeConfig
      */
     public int $flushQueueSize;
     /**
-     * The maximum retry attempts for an event when receiving error response.
+     * The minimum length of the id field in events. Default to 5.
      */
     public int $minIdLength;
     /**

--- a/src/Amplitude/AmplitudeConfigBuilder.php
+++ b/src/Amplitude/AmplitudeConfigBuilder.php
@@ -3,6 +3,7 @@
 namespace AmplitudeExperiment\Amplitude;
 
 use AmplitudeExperiment\Http\HttpClientInterface;
+use Psr\Log\LoggerInterface;
 
 class AmplitudeConfigBuilder
 {
@@ -16,6 +17,8 @@ class AmplitudeConfigBuilder
      * @var array<string, mixed>
      */
     protected array $guzzleClientConfig = AmplitudeConfig::DEFAULTS['guzzleClientConfig'];
+    protected ?LoggerInterface $logger = AmplitudeConfig::DEFAULTS['logger'];
+    protected int $logLevel = AmplitudeConfig::DEFAULTS['logLevel'];
 
     public function __construct()
     {
@@ -66,10 +69,20 @@ class AmplitudeConfigBuilder
         return $this;
     }
 
-    /**
-     * @phpstan-ignore-next-line
-     */
-    public function build()
+    public function logger(LoggerInterface $logger): AmplitudeConfigBuilder
+    {
+        $this->logger = $logger;
+        return $this;
+    }
+
+    public function logLevel(int $logLevel): AmplitudeConfigBuilder
+    {
+        $this->logLevel = $logLevel;
+        return $this;
+    }
+
+
+    public function build(): AmplitudeConfig
     {
         if (!$this->serverUrl) {
             if ($this->useBatch) {
@@ -85,7 +98,9 @@ class AmplitudeConfigBuilder
             $this->serverUrl,
             $this->useBatch,
             $this->httpClient,
-            $this->guzzleClientConfig
+            $this->guzzleClientConfig,
+            $this->logger,
+            $this->logLevel
         );
     }
 }

--- a/src/Amplitude/Event.php
+++ b/src/Amplitude/Event.php
@@ -2,6 +2,13 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+/**
+ * Event class for tracking assignments to Amplitude Experiment.
+ *
+ * This object contains all the required information to send an `$assignment`
+ * event to experiment.
+ */
+
 class Event
 {
     public ?string $eventType = null;

--- a/src/Amplitude/Event.php
+++ b/src/Amplitude/Event.php
@@ -4,13 +4,6 @@ namespace AmplitudeExperiment\Amplitude;
 
 use RuntimeException;
 
-/**
- * Event class for tracking assignments to Amplitude Experiment.
- *
- * This object contains all the required information to send an `$assignment`
- * event to experiment.
- */
-
 class Event
 {
     public ?string $eventType = null;

--- a/src/Amplitude/Event.php
+++ b/src/Amplitude/Event.php
@@ -2,6 +2,8 @@
 
 namespace AmplitudeExperiment\Amplitude;
 
+use RuntimeException;
+
 /**
  * Event class for tracking assignments to Amplitude Experiment.
  *
@@ -41,5 +43,17 @@ class Event
             'user_id' => $this->userId,
             'device_id' => $this->deviceId,
             'insert_id' => $this->insertId,]);
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function toJSONString(): string
+    {
+        $jsonString = json_encode($this->toArray());
+        if (!$jsonString) {
+            throw new RuntimeException('Failed to encode Event to JSON string');
+        }
+        return $jsonString;
     }
 }

--- a/src/Assignment/Assignment.php
+++ b/src/Assignment/Assignment.php
@@ -8,6 +8,9 @@ use AmplitudeExperiment\Variant;
 use RuntimeException;
 use function AmplitudeExperiment\hashCode;
 
+require_once __DIR__  . '/../Util.php';
+require_once __DIR__ . '/AssignmentService.php';
+
 /**
  * Event class for tracking assignments to Amplitude Experiment.
  */

--- a/src/Assignment/Assignment.php
+++ b/src/Assignment/Assignment.php
@@ -2,8 +2,11 @@
 
 namespace AmplitudeExperiment\Assignment;
 
+use AmplitudeExperiment\Amplitude\Event;
 use AmplitudeExperiment\User;
 use AmplitudeExperiment\Variant;
+use RuntimeException;
+use function AmplitudeExperiment\hashCode;
 
 class Assignment
 {
@@ -13,15 +16,19 @@ class Assignment
      */
     public array $variants;
     public int $timestamp;
+    public string $apiKey;
+    public int $minIdLength;
 
     /**
      * @param array<string, Variant> $variants
      */
-    public function __construct(User $user, array $variants)
+    public function __construct(User $user, array $variants, string $apiKey = '', int $minIdLength = AssignmentConfig::DEFAULTS['minIdLength'])
     {
         $this->user = $user;
         $this->variants = $variants;
-        $this->timestamp = (int) floor(microtime(true) * 1000);
+        $this->timestamp = (int)floor(microtime(true) * 1000);
+        $this->apiKey = $apiKey;
+        $this->minIdLength = $minIdLength;
     }
 
     public function canonicalize(): string
@@ -37,5 +44,87 @@ class Assignment
             $canonical .= trim($key) . ' ' . trim($variant->key) . ' ';
         }
         return $canonical;
+    }
+
+    /**
+     * Convert an Assignment to an Amplitude event
+     */
+    public function toEvent(): Event
+    {
+        $event = new Event('[Experiment] Assignment');
+        $event->userId = $this->user->userId;
+        $event->deviceId = $this->user->deviceId;
+        $event->eventProperties = [];
+        $event->userProperties = [];
+
+        $set = [];
+        $unset = [];
+        foreach ($this->variants as $flagKey => $variant) {
+            if (!$variant->key) {
+                continue;
+            }
+            $event->eventProperties["{$flagKey}.variant"] = $variant->key;
+            $version = $variant->metadata['flagVersion'] ?? null;
+            $segmentName = $variant->metadata['segmentName'] ?? null;
+            if ($version && $segmentName) {
+                $event->eventProperties["{$flagKey}.details"] = "v{$version} rule:{$segmentName}";
+            }
+            $flagType = $variant->metadata['flagType'] ?? null;
+            $default = $variant->metadata['default'] ?? false;
+            if ($flagType == FLAG_TYPE_MUTUAL_EXCLUSION_GROUP) {
+                continue;
+            } elseif ($default) {
+                $unset["[Experiment] {$flagKey}"] = '-';
+            } else {
+                $set["[Experiment] {$flagKey}"] = $variant->key;
+            }
+        }
+
+        $event->userProperties['$set'] = $set;
+        $event->userProperties['$unset'] = $unset;
+
+        $hash = hashCode($this->canonicalize());
+
+        $event->insertId = "{$event->userId} {$event->deviceId} {$hash} " .
+            floor($this->timestamp / DAY_MILLIS);
+
+        return $event;
+    }
+
+
+    /**
+     * Convert an Assignment to an array representation of an Amplitude event
+     * @return array<string, mixed>
+     */
+    public function toJSONArray(): array
+    {
+        return $this->toEvent()->toArray();
+    }
+
+    /**
+     * Convert an Assignment to an Amplitude event JSON string
+     * @throws RuntimeException
+     */
+    public function toJSONString(): string
+    {
+        $jsonString = json_encode($this->toJSONArray());
+        if (!$jsonString) {
+            throw new RuntimeException('Failed to encode Assignment to JSON string');
+        }
+        return $jsonString;
+    }
+
+    /**
+     * Convert an Assignment to a JSON string that can be used as a payload to the Amplitude event upload API
+     * @throws RuntimeException
+     */
+    public function toJSONPayload(): string
+    {
+        $payload = ["api_key" => $this->apiKey, "events" => [$this->toEvent()], "options" => ["min_id_length" => $this->minIdLength]];
+        $jsonString = json_encode($payload);
+        if (!$jsonString) {
+            throw new RuntimeException('Failed to encode Assignment to JSON payload');
+        }
+        return $jsonString;
     }
 }

--- a/src/Assignment/Assignment.php
+++ b/src/Assignment/Assignment.php
@@ -8,6 +8,9 @@ use AmplitudeExperiment\Variant;
 use RuntimeException;
 use function AmplitudeExperiment\hashCode;
 
+/**
+ * Event class for tracking assignments to Amplitude Experiment.
+ */
 class Assignment
 {
     public User $user;
@@ -96,7 +99,7 @@ class Assignment
      * Convert an Assignment to an array representation of an Amplitude event
      * @return array<string, mixed>
      */
-    public function toJSONArray(): array
+    public function toArray(): array
     {
         return $this->toEvent()->toArray();
     }
@@ -107,7 +110,7 @@ class Assignment
      */
     public function toJSONString(): string
     {
-        $jsonString = json_encode($this->toJSONArray());
+        $jsonString = json_encode($this->toArray());
         if (!$jsonString) {
             throw new RuntimeException('Failed to encode Assignment to JSON string');
         }

--- a/src/Assignment/AssignmentConfig.php
+++ b/src/Assignment/AssignmentConfig.php
@@ -2,46 +2,35 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-
 /**
  * Configuration options for assignment tracking. This is an object that can be created using
- * a {@link AssignmentConfigBuilder}, which also sets options for {@link AmplitudeConfig}. Example usage:
+ * a {@link AssignmentConfigBuilder}. Example usage:
  *
  * ```
- * AssignmentConfigBuilder::builder('api-key')->minIdLength(10)->build();
+ * AssignmentConfigBuilder::builder('api-key')->cacheCapacity(1000)->build();
  * ```
  */
 
 class AssignmentConfig
 {
     /**
-     * The Amplitude Analytics API key.
-     */
-    public string $apiKey;
-    /**
      * The maximum number of assignments stored in the assignment cache
      */
     public int $cacheCapacity;
-    /**
-     * Configuration options for the underlying {@link Amplitude} client. This is created when
-     * calling {@link AssignmentConfigBuilder::build()} and does not need to be explicitly set.
-     */
-    public AmplitudeConfig $amplitudeConfig;
+    public AssignmentTrackingProvider $assignmentTrackingProvider;
 
     const DEFAULTS = [
         'cacheCapacity' => 65536,
     ];
 
-    public function __construct(string $apiKey, int $cacheCapacity, AmplitudeConfig $amplitudeConfig)
+    public function __construct(int $cacheCapacity, AssignmentTrackingProvider $assignmentTrackingProvider)
     {
-        $this->apiKey = $apiKey;
         $this->cacheCapacity = $cacheCapacity;
-        $this->amplitudeConfig = $amplitudeConfig;
+        $this->assignmentTrackingProvider = $assignmentTrackingProvider;
     }
 
-    public static function builder(string $apiKey): AssignmentConfigBuilder
+    public static function builder(AssignmentTrackingProvider $assignmentTrackingProvider): AssignmentConfigBuilder
     {
-        return new AssignmentConfigBuilder($apiKey);
+        return new AssignmentConfigBuilder($assignmentTrackingProvider);
     }
 }

--- a/src/Assignment/AssignmentConfig.php
+++ b/src/Assignment/AssignmentConfig.php
@@ -2,6 +2,8 @@
 
 namespace AmplitudeExperiment\Assignment;
 
+use AmplitudeExperiment\Amplitude\AmplitudeConfig;
+
 /**
  * Configuration options for assignment tracking. This is an object that can be created using
  * a {@link AssignmentConfigBuilder}. Example usage:
@@ -17,20 +19,35 @@ class AssignmentConfig
      * The maximum number of assignments stored in the assignment cache
      */
     public int $cacheCapacity;
+    /**
+     * The provider for tracking assignment events to Amplitude
+     */
     public AssignmentTrackingProvider $assignmentTrackingProvider;
+    /**
+     * The API key for the Amplitude project.
+     */
+    public string $apiKey;
+    /**
+     * The minimum length of the id field in events. Default to 5. This is set in {@link AmplitudeConfig} if the
+     * {@link DefaultAssignmentTrackingProvider} is used, and does not need to be set here.
+     */
+    public int $minIdLength;
 
     const DEFAULTS = [
         'cacheCapacity' => 65536,
+        'minIdLength' => 5,
     ];
 
-    public function __construct(int $cacheCapacity, AssignmentTrackingProvider $assignmentTrackingProvider)
+    public function __construct(int $cacheCapacity, AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey, int $minIdLength)
     {
         $this->cacheCapacity = $cacheCapacity;
         $this->assignmentTrackingProvider = $assignmentTrackingProvider;
+        $this->apiKey = $apiKey;
+        $this->minIdLength = $minIdLength;
     }
 
-    public static function builder(AssignmentTrackingProvider $assignmentTrackingProvider): AssignmentConfigBuilder
+    public static function builder(AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey): AssignmentConfigBuilder
     {
-        return new AssignmentConfigBuilder($assignmentTrackingProvider);
+        return new AssignmentConfigBuilder($assignmentTrackingProvider, $apiKey);
     }
 }

--- a/src/Assignment/AssignmentConfig.php
+++ b/src/Assignment/AssignmentConfig.php
@@ -14,7 +14,7 @@ namespace AmplitudeExperiment\Assignment;
 class AssignmentConfig
 {
     /**
-     * The API key for the Amplitude project.
+     * The Amplitude Project API key.
      */
     public string $apiKey;
     /**

--- a/src/Assignment/AssignmentConfig.php
+++ b/src/Assignment/AssignmentConfig.php
@@ -2,8 +2,6 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-
 /**
  * Configuration options for assignment tracking. This is an object that can be created using
  * a {@link AssignmentConfigBuilder}. Example usage:
@@ -16,6 +14,10 @@ use AmplitudeExperiment\Amplitude\AmplitudeConfig;
 class AssignmentConfig
 {
     /**
+     * The API key for the Amplitude project.
+     */
+    public string $apiKey;
+    /**
      * The maximum number of assignments stored in the assignment cache
      */
     public int $cacheCapacity;
@@ -23,10 +25,6 @@ class AssignmentConfig
      * The provider for tracking assignment events to Amplitude
      */
     public AssignmentTrackingProvider $assignmentTrackingProvider;
-    /**
-     * The API key for the Amplitude project.
-     */
-    public string $apiKey;
     /**
      * The minimum length of the id field in events. Default to 5. This is set in {@link AmplitudeConfig} if the
      * {@link DefaultAssignmentTrackingProvider} is used, and does not need to be set here.
@@ -38,16 +36,16 @@ class AssignmentConfig
         'minIdLength' => 5,
     ];
 
-    public function __construct(int $cacheCapacity, AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey, int $minIdLength)
+    public function __construct(string $apiKey, int $cacheCapacity, AssignmentTrackingProvider $assignmentTrackingProvider, int $minIdLength)
     {
+        $this->apiKey = $apiKey;
         $this->cacheCapacity = $cacheCapacity;
         $this->assignmentTrackingProvider = $assignmentTrackingProvider;
-        $this->apiKey = $apiKey;
         $this->minIdLength = $minIdLength;
     }
 
-    public static function builder(AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey): AssignmentConfigBuilder
+    public static function builder(string $apiKey, AssignmentTrackingProvider $assignmentTrackingProvider): AssignmentConfigBuilder
     {
-        return new AssignmentConfigBuilder($assignmentTrackingProvider, $apiKey);
+        return new AssignmentConfigBuilder($apiKey, $assignmentTrackingProvider);
     }
 }

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -9,10 +9,10 @@ class AssignmentConfigBuilder
     protected string $apiKey;
     protected int $minIdLength = AssignmentConfig::DEFAULTS['minIdLength'];
 
-    public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey)
+    public function __construct(string $apiKey, AssignmentTrackingProvider $assignmentTrackingProvider)
     {
-        $this->assignmentTrackingProvider = $assignmentTrackingProvider;
         $this->apiKey = $apiKey;
+        $this->assignmentTrackingProvider = $assignmentTrackingProvider;
     }
 
     public function cacheCapacity(int $cacheCapacity): AssignmentConfigBuilder
@@ -30,9 +30,9 @@ class AssignmentConfigBuilder
     public function build(): AssignmentConfig
     {
         return new AssignmentConfig(
+            $this->apiKey,
             $this->cacheCapacity,
             $this->assignmentTrackingProvider,
-            $this->apiKey,
             $this->minIdLength
         );
     }

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -6,10 +6,13 @@ class AssignmentConfigBuilder
 {
     protected int $cacheCapacity = AssignmentConfig::DEFAULTS['cacheCapacity'];
     protected AssignmentTrackingProvider $assignmentTrackingProvider;
+    protected string $apiKey;
+    protected int $minIdLength = AssignmentConfig::DEFAULTS['minIdLength'];
 
-    public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider)
+    public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider, string $apiKey)
     {
         $this->assignmentTrackingProvider = $assignmentTrackingProvider;
+        $this->apiKey = $apiKey;
     }
 
     public function cacheCapacity(int $cacheCapacity): AssignmentConfigBuilder
@@ -18,11 +21,19 @@ class AssignmentConfigBuilder
         return $this;
     }
 
+    public function minIdLength(int $minIdLength): AssignmentConfigBuilder
+    {
+        $this->minIdLength = $minIdLength;
+        return $this;
+    }
+
     public function build(): AssignmentConfig
     {
         return new AssignmentConfig(
             $this->cacheCapacity,
-            $this->assignmentTrackingProvider
+            $this->assignmentTrackingProvider,
+            $this->apiKey,
+            $this->minIdLength
         );
     }
 }

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -9,6 +9,7 @@ class AssignmentConfigBuilder
 
     public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider)
     {
+        $this->assignmentTrackingProvider = $assignmentTrackingProvider;
     }
 
     public function cacheCapacity(int $cacheCapacity): AssignmentConfigBuilder

--- a/src/Assignment/AssignmentConfigBuilder.php
+++ b/src/Assignment/AssignmentConfigBuilder.php
@@ -2,21 +2,13 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-use AmplitudeExperiment\Amplitude\AmplitudeConfigBuilder;
-
-/**
- * Extends AmplitudeConfigBuilder to allow configuration {@link AmplitudeConfig} of underlying {@link Amplitude} client.
- */
-class AssignmentConfigBuilder extends AmplitudeConfigBuilder
+class AssignmentConfigBuilder
 {
-    protected string $apiKey;
     protected int $cacheCapacity = AssignmentConfig::DEFAULTS['cacheCapacity'];
+    protected AssignmentTrackingProvider $assignmentTrackingProvider;
 
-    public function __construct(string $apiKey)
+    public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider)
     {
-        parent::__construct();
-        $this->apiKey = $apiKey;
     }
 
     public function cacheCapacity(int $cacheCapacity): AssignmentConfigBuilder
@@ -25,15 +17,11 @@ class AssignmentConfigBuilder extends AmplitudeConfigBuilder
         return $this;
     }
 
-    /**
-     * @phpstan-ignore-next-line
-     */
-    public function build()
+    public function build(): AssignmentConfig
     {
         return new AssignmentConfig(
-            $this->apiKey,
             $this->cacheCapacity,
-            parent::build()
+            $this->assignmentTrackingProvider
         );
     }
 }

--- a/src/Assignment/AssignmentService.php
+++ b/src/Assignment/AssignmentService.php
@@ -13,19 +13,19 @@ const DAY_MILLIS = 24 * 60 * 60 * 1000;
 
 class AssignmentService
 {
-    private Amplitude $amplitude;
+    private AssignmentTrackingProvider $assignmentTrackingProvider;
     private AssignmentFilter $assignmentFilter;
 
-    public function __construct(Amplitude $amplitude, AssignmentFilter $assignmentFilter)
+    public function __construct(AssignmentTrackingProvider $assignmentTrackingProvider, AssignmentFilter $assignmentFilter)
     {
-        $this->amplitude = $amplitude;
+        $this->assignmentTrackingProvider = $assignmentTrackingProvider;
         $this->assignmentFilter = $assignmentFilter;
     }
 
     public function track(Assignment $assignment): void
     {
         if ($this->assignmentFilter->shouldTrack($assignment)) {
-            $this->amplitude->logEvent($this->toEvent($assignment));
+            $this->assignmentTrackingProvider->track($this->toEvent($assignment));
         }
     }
 

--- a/src/Assignment/AssignmentTrackingProvider.php
+++ b/src/Assignment/AssignmentTrackingProvider.php
@@ -2,8 +2,6 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-use AmplitudeExperiment\Local\LocalEvaluationClient;
-
 /**
  * An interface for tracking assignments to Amplitude Experiment during local evaluation.
  *
@@ -22,7 +20,7 @@ interface AssignmentTrackingProvider
      * Use {@link Assignment::toJSONPayload()} to convert the Assignment to a JSON string which can be used as a payload
      * to the Amplitude event upload API.
      *
-     * Use {@link Assignment::toJSONArray()} to convert the Assignment to an array representation of an Amplitude event
+     * Use {@link Assignment::toArray()} to convert the Assignment to an array representation of an Amplitude event
      *
      * Used {@link Assignment::toJSONString()} to convert the Assignment to an Amplitude event JSON string
      *

--- a/src/Assignment/AssignmentTrackingProvider.php
+++ b/src/Assignment/AssignmentTrackingProvider.php
@@ -2,21 +2,30 @@
 
 namespace AmplitudeExperiment\Assignment;
 
-use AmplitudeExperiment\Amplitude\Event;
+use AmplitudeExperiment\Local\LocalEvaluationClient;
 
 /**
- * An interface for tracking assignments to Amplitude Experiment.
+ * An interface for tracking assignments to Amplitude Experiment during local evaluation.
  *
  * See {@link https://www.docs.developers.amplitude.com/analytics/apis/batch-event-upload-api/} for more information
  * on how to send events to Amplitude.
  *
- * Use {@link Event::toArray()} to convert an event to the proper array format before sending it to Amplitude.
- *
- * {@link DefaultAssignmentTrackingProvider} is provided as a default implementation. However, a custom implementation
- * is recommended for increased flexibility and efficiency.
+ * {@link DefaultAssignmentTrackingProvider} is provided as a default synchronous implementation.
+ * However, a custom implementation is recommended for increased flexibility and efficiency.
  */
 
 interface AssignmentTrackingProvider
 {
-    public function track(Event $event): void;
+    /**
+     * Called when {@link LocalEvaluationClient} intends to track an Assignment event
+     *
+     * Use {@link Assignment::toJSONPayload()} to convert the Assignment to a JSON string which can be used as a payload
+     * to the Amplitude event upload API.
+     *
+     * Use {@link Assignment::toJSONArray()} to convert the Assignment to an array representation of an Amplitude event
+     *
+     * Used {@link Assignment::toJSONString()} to convert the Assignment to an Amplitude event JSON string
+     *
+     */
+    public function track(Assignment $assignment): void;
 }

--- a/src/Assignment/AssignmentTrackingProvider.php
+++ b/src/Assignment/AssignmentTrackingProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AmplitudeExperiment\Assignment;
+
+use AmplitudeExperiment\Amplitude\Event;
+
+/**
+ * An interface for tracking assignments to Amplitude Experiment.
+ *
+ * See {@link https://www.docs.developers.amplitude.com/analytics/apis/batch-event-upload-api/} for more information
+ * on how to send events to Amplitude.
+ *
+ * Use {@link Event::toArray()} to convert an event to the proper array format before sending it to Amplitude.
+ *
+ * {@link DefaultAssignmentTrackingProvider} is provided as a default implementation. However, a custom implementation
+ * is recommended for increased flexibility and efficiency.
+ */
+
+interface AssignmentTrackingProvider
+{
+    public function track(Event $event): void;
+}

--- a/src/Assignment/DefaultAssignmentTrackingProvider.php
+++ b/src/Assignment/DefaultAssignmentTrackingProvider.php
@@ -17,8 +17,8 @@ class DefaultAssignmentTrackingProvider implements AssignmentTrackingProvider
         $this->amplitude = $amplitude;
     }
 
-    public function track(Event $event): void
+    public function track(Assignment $assignment): void
     {
-        $this->amplitude->logEvent($event);
+        $this->amplitude->logEvent($assignment->toEvent());
     }
 }

--- a/src/Assignment/DefaultAssignmentTrackingProvider.php
+++ b/src/Assignment/DefaultAssignmentTrackingProvider.php
@@ -3,8 +3,6 @@
 namespace AmplitudeExperiment\Assignment;
 
 use AmplitudeExperiment\Amplitude\Amplitude;
-use AmplitudeExperiment\Amplitude\AmplitudeConfig;
-use AmplitudeExperiment\Amplitude\Event;
 
 /**
  * A default implementation of the AssignmentTrackingProvider interface.

--- a/src/Assignment/DefaultAssignmentTrackingProvider.php
+++ b/src/Assignment/DefaultAssignmentTrackingProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AmplitudeExperiment\Assignment;
+
+use AmplitudeExperiment\Amplitude\Amplitude;
+use AmplitudeExperiment\Amplitude\AmplitudeConfig;
+use AmplitudeExperiment\Amplitude\Event;
+
+/**
+ * A default implementation of the AssignmentTrackingProvider interface.
+ */
+class DefaultAssignmentTrackingProvider implements AssignmentTrackingProvider
+{
+    private Amplitude $amplitude;
+    public function __construct(Amplitude $amplitude)
+    {
+        $this->amplitude = $amplitude;
+    }
+
+    public function track(Event $event): void
+    {
+        $this->amplitude->logEvent($event);
+    }
+}

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -74,7 +74,7 @@ class LocalEvaluationClient
         $results = array_map('AmplitudeExperiment\Variant::convertEvaluationVariantToVariant', $this->evaluation->evaluate($user->toEvaluationContext(), $flags));
         $this->logger->debug('[Experiment] Evaluate - variants:' . json_encode($results));
         if ($this->assignmentService) {
-            $this->assignmentService->track(new Assignment($user, $results));
+            $this->assignmentService->track($this->assignmentService->createAssignment($user, $results));
         }
         return $results;
     }
@@ -93,7 +93,9 @@ class LocalEvaluationClient
         if ($config) {
             $this->assignmentService = new AssignmentService(
                 $config->assignmentTrackingProvider,
-                new AssignmentFilter($config->cacheCapacity));
+                new AssignmentFilter($config->cacheCapacity),
+                $config->apiKey,
+                $config->minIdLength);
         }
     }
 }

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -2,7 +2,6 @@
 
 namespace AmplitudeExperiment\Local;
 
-use AmplitudeExperiment\Assignment\Assignment;
 use AmplitudeExperiment\Assignment\AssignmentConfig;
 use AmplitudeExperiment\Assignment\AssignmentFilter;
 use AmplitudeExperiment\Assignment\AssignmentService;

--- a/src/Local/LocalEvaluationClient.php
+++ b/src/Local/LocalEvaluationClient.php
@@ -2,7 +2,6 @@
 
 namespace AmplitudeExperiment\Local;
 
-use AmplitudeExperiment\Amplitude\Amplitude;
 use AmplitudeExperiment\Assignment\Assignment;
 use AmplitudeExperiment\Assignment\AssignmentConfig;
 use AmplitudeExperiment\Assignment\AssignmentFilter;
@@ -93,9 +92,7 @@ class LocalEvaluationClient
     {
         if ($config) {
             $this->assignmentService = new AssignmentService(
-                new Amplitude($config->apiKey,
-                    $this->logger,
-                    $config->amplitudeConfig),
+                $config->assignmentTrackingProvider,
                 new AssignmentFilter($config->cacheCapacity));
         }
     }

--- a/tests/Amplitude/AmplitudeTest.php
+++ b/tests/Amplitude/AmplitudeTest.php
@@ -18,13 +18,7 @@ use Psr\Log\LoggerInterface;
 
 class AmplitudeTest extends TestCase
 {
-    private LoggerInterface $logger;
     const API_KEY = 'test';
-
-    public function setUp(): void
-    {
-        $this->logger = new InternalLogger(new DefaultLogger(), LogLevel::DEBUG);
-    }
 
     public function testAmplitudeConfigServerUrl()
     {
@@ -53,7 +47,7 @@ class AmplitudeTest extends TestCase
 
     public function testEmptyQueueAfterFlushSuccess()
     {
-        $client = new MockAmplitude(self::API_KEY, $this->logger);
+        $client = new MockAmplitude(self::API_KEY);
         $mock = new MockHandler([
             new Response(200, ['X-Foo' => 'Bar']),
         ]);
@@ -79,7 +73,7 @@ class AmplitudeTest extends TestCase
         $config = AmplitudeConfig::builder()
             ->flushQueueSize(3)
             ->build();
-        $client = new MockAmplitude(self::API_KEY, $this->logger, $config);
+        $client = new MockAmplitude(self::API_KEY, $config);
         $mockHandler = new MockHandler([
             function (RequestInterface $request, array $options) use (&$requestCounter) {
                 $requestCounter++;
@@ -110,7 +104,7 @@ class AmplitudeTest extends TestCase
         // Initialize the request counter
         $requestCounter = 0;
         $config = AmplitudeConfig::builder()->build();
-        $client = new MockAmplitude(self::API_KEY, $this->logger, $config);
+        $client = new MockAmplitude(self::API_KEY, $config);
 
         // Set up the mock handler with request counter incrementation logic
         $mockHandler = new MockHandler(array_fill(1, 5, function (RequestInterface $request, array $options) use (&$requestCounter) {
@@ -138,7 +132,7 @@ class AmplitudeTest extends TestCase
         // Initialize the request counter
         $requestCounter = 0;
         $config = AmplitudeConfig::builder()->build();
-        $client = new MockAmplitude(self::API_KEY, $this->logger, $config);
+        $client = new MockAmplitude(self::API_KEY, $config);
 
         // Set up the mock handler with request counter incrementation logic
         $mockHandler = new MockHandler(array_fill(1, 2, function (RequestInterface $request, array $options) use (&$requestCounter) {

--- a/tests/Amplitude/MockAmplitude.php
+++ b/tests/Amplitude/MockAmplitude.php
@@ -9,9 +9,9 @@ use Psr\Log\LoggerInterface;
 
 class MockAmplitude extends Amplitude
 {
-    public function __construct(string $apiKey, LoggerInterface $logger, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, AmplitudeConfig $config = null)
     {
-        parent::__construct($apiKey, $logger, $config);
+        parent::__construct($apiKey, $config);
     }
     public function setHttpClient(HttpClientInterface $httpClient) {
         $this->httpClient = $httpClient;

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -51,7 +51,7 @@ class AssignmentServiceTest extends TestCase
         ];
 
         $assignment = new Assignment($user, $results);
-        $event = AssignmentService::toEvent($assignment);
+        $event = $assignment->toEvent();
 
         $this->assertEquals($user->userId, $event->userId);
         $this->assertEquals($user->deviceId, $event->deviceId);

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -6,6 +6,7 @@ use AmplitudeExperiment\Amplitude\Amplitude;
 use AmplitudeExperiment\Assignment\Assignment;
 use AmplitudeExperiment\Assignment\AssignmentFilter;
 use AmplitudeExperiment\Assignment\AssignmentService;
+use AmplitudeExperiment\Assignment\DefaultAssignmentTrackingProvider;
 use AmplitudeExperiment\Logger\DefaultLogger;
 use AmplitudeExperiment\Logger\InternalLogger;
 use AmplitudeExperiment\Logger\LogLevel;
@@ -89,13 +90,14 @@ class AssignmentServiceTest extends TestCase
     {
         $assignmentFilter = new AssignmentFilter(1);
         $mockAmp = $this->getMockBuilder(Amplitude::class)
-            ->setConstructorArgs(['', new InternalLogger(new DefaultLogger(), LogLevel::INFO)])
+            ->setConstructorArgs([''])
             ->onlyMethods(['logEvent'])
             ->getMock();
         $results = [
             'flag-key-1' => new Variant('on')
         ];
-        $service = new AssignmentService($mockAmp, $assignmentFilter);
+        $assigmentTrackingProvider = new DefaultAssignmentTrackingProvider($mockAmp);
+        $service = new AssignmentService($assigmentTrackingProvider, $assignmentFilter);
         $mockAmp->expects($this->once())->method('logEvent');
         $service->track(new Assignment(User::builder()->userId('user')->build(), $results));
     }

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -10,81 +10,9 @@ use AmplitudeExperiment\Assignment\DefaultAssignmentTrackingProvider;
 use AmplitudeExperiment\User;
 use AmplitudeExperiment\Variant;
 use PHPUnit\Framework\TestCase;
-use const AmplitudeExperiment\Assignment\DAY_MILLIS;
-use function AmplitudeExperiment\hashCode;
-
-require_once __DIR__ . '/../../src/Util.php';
 
 class AssignmentServiceTest extends TestCase
 {
-    public function testAssignmentToEventAsExpected()
-    {
-        $user = User::builder()->userId('user')->deviceId('device')->build();
-        $results = [
-            'basic' => new Variant(
-                'control', 'control', null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => false]
-            ),
-            'different_value' => new Variant(
-                'on', 'control', null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => false]
-            ),
-            'default' => new Variant(
-                'off', null, null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => true]
-            ),
-            'mutex' => new Variant(
-                'slot-1', 'slot-1', null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'mutual-exclusion-group', 'flagVersion' => 10, 'default' => false]
-            ),
-            'holdout' => new Variant('holdout', 'holdout', null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'holdout-group', 'flagVersion' => 10, 'default' => false]
-            ),
-            'partial_metadata' => new Variant('on', 'on', null, null,
-                ['segmentName' => 'All Other Users', 'flagType' => 'release']
-            ),
-            'empty_metadata' => new Variant('on', 'on'),
-            'empty_variant' => new Variant()
-        ];
-
-        $assignment = new Assignment($user, $results, 'apiKey', 10);
-        $event = $assignment->toEvent();
-
-        $this->assertEquals($user->userId, $event->userId);
-        $this->assertEquals($user->deviceId, $event->deviceId);
-        $this->assertEquals('[Experiment] Assignment', $event->eventType);
-
-        $eventProperties = $event->eventProperties;
-        $this->assertEquals('control', $eventProperties['basic.variant']);
-        $this->assertEquals('v10 rule:All Other Users', $eventProperties['basic.details']);
-        $this->assertEquals('on', $eventProperties['different_value.variant']);
-        $this->assertEquals('v10 rule:All Other Users', $eventProperties['different_value.details']);
-        $this->assertEquals('off', $eventProperties['default.variant']);
-        $this->assertEquals('v10 rule:All Other Users', $eventProperties['default.details']);
-        $this->assertEquals('slot-1', $eventProperties['mutex.variant']);
-        $this->assertEquals('v10 rule:All Other Users', $eventProperties['mutex.details']);
-        $this->assertEquals('holdout', $eventProperties['holdout.variant']);
-        $this->assertEquals('v10 rule:All Other Users', $eventProperties['holdout.details']);
-        $this->assertEquals('on', $eventProperties['partial_metadata.variant']);
-        $this->assertEquals('on', $eventProperties['empty_metadata.variant']);
-
-        $userProperties = $event->userProperties;
-        $setProperties = $userProperties['$set'];
-        $this->assertEquals('control', $setProperties['[Experiment] basic']);
-        $this->assertEquals('on', $setProperties['[Experiment] different_value']);
-        $this->assertEquals('holdout', $setProperties['[Experiment] holdout']);
-        $this->assertEquals('on', $setProperties['[Experiment] partial_metadata']);
-        $this->assertEquals('on', $setProperties['[Experiment] empty_metadata']);
-        $unsetProperties = $userProperties['$unset'];
-        $this->assertEquals('-', $unsetProperties['[Experiment] default']);
-
-        $canonicalization = 'user device basic control default off different_value on empty_metadata on holdout holdout mutex slot-1 partial_metadata on ';
-        $expected = "user device " . hashCode($canonicalization) . ' ' . floor($assignment->timestamp / DAY_MILLIS);
-        $this->assertEquals($expected, $event->insertId);
-        $expectedPayload = json_encode(["api_key" => 'apiKey', "events" => [$event], "options" => ["min_id_length" => 10]]);
-        $this->assertEquals($expectedPayload, $assignment->toJSONPayload());
-    }
-
     public function testlogEventCalledInAmplitude()
     {
         $assignmentFilter = new AssignmentFilter(1);

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -7,9 +7,6 @@ use AmplitudeExperiment\Assignment\Assignment;
 use AmplitudeExperiment\Assignment\AssignmentFilter;
 use AmplitudeExperiment\Assignment\AssignmentService;
 use AmplitudeExperiment\Assignment\DefaultAssignmentTrackingProvider;
-use AmplitudeExperiment\Logger\DefaultLogger;
-use AmplitudeExperiment\Logger\InternalLogger;
-use AmplitudeExperiment\Logger\LogLevel;
 use AmplitudeExperiment\User;
 use AmplitudeExperiment\Variant;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +47,7 @@ class AssignmentServiceTest extends TestCase
             'empty_variant' => new Variant()
         ];
 
-        $assignment = new Assignment($user, $results);
+        $assignment = new Assignment($user, $results, 'apiKey', 10);
         $event = $assignment->toEvent();
 
         $this->assertEquals($user->userId, $event->userId);
@@ -84,6 +81,9 @@ class AssignmentServiceTest extends TestCase
         $canonicalization = 'user device basic control default off different_value on empty_metadata on holdout holdout mutex slot-1 partial_metadata on ';
         $expected = "user device " . hashCode($canonicalization) . ' ' . floor($assignment->timestamp / DAY_MILLIS);
         $this->assertEquals($expected, $event->insertId);
+        $expectedPayload = json_encode(["api_key" => 'apiKey', "events" => [$event], "options" => ["min_id_length" => 10]]);
+        $this->assertEquals($expectedPayload, $assignment->toJSONPayload());
+        echo $assignment->toJSONPayload() . "\n";
     }
 
     public function testlogEventCalledInAmplitude()

--- a/tests/Assignment/AssignmentServiceTest.php
+++ b/tests/Assignment/AssignmentServiceTest.php
@@ -83,7 +83,6 @@ class AssignmentServiceTest extends TestCase
         $this->assertEquals($expected, $event->insertId);
         $expectedPayload = json_encode(["api_key" => 'apiKey', "events" => [$event], "options" => ["min_id_length" => 10]]);
         $this->assertEquals($expectedPayload, $assignment->toJSONPayload());
-        echo $assignment->toJSONPayload() . "\n";
     }
 
     public function testlogEventCalledInAmplitude()

--- a/tests/Assignment/AssignmentTest.php
+++ b/tests/Assignment/AssignmentTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AmplitudeExperiment\Test\Assignment;
+
+use AmplitudeExperiment\Assignment\Assignment;
+use AmplitudeExperiment\User;
+use AmplitudeExperiment\Variant;
+use PHPUnit\Framework\TestCase;
+use function AmplitudeExperiment\hashCode;
+use const AmplitudeExperiment\Assignment\DAY_MILLIS;
+
+class AssignmentTest extends TestCase
+{
+    public function testAssignmentToEventAsExpected()
+    {
+        $user = User::builder()->userId('user')->deviceId('device')->build();
+        $results = [
+            'basic' => new Variant(
+                'control', 'control', null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => false]
+            ),
+            'different_value' => new Variant(
+                'on', 'control', null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => false]
+            ),
+            'default' => new Variant(
+                'off', null, null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'experiment', 'flagVersion' => 10, 'default' => true]
+            ),
+            'mutex' => new Variant(
+                'slot-1', 'slot-1', null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'mutual-exclusion-group', 'flagVersion' => 10, 'default' => false]
+            ),
+            'holdout' => new Variant('holdout', 'holdout', null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'holdout-group', 'flagVersion' => 10, 'default' => false]
+            ),
+            'partial_metadata' => new Variant('on', 'on', null, null,
+                ['segmentName' => 'All Other Users', 'flagType' => 'release']
+            ),
+            'empty_metadata' => new Variant('on', 'on'),
+            'empty_variant' => new Variant()
+        ];
+
+        $assignment = new Assignment($user, $results, 'apiKey', 10);
+        $event = $assignment->toEvent();
+
+        $this->assertEquals($user->userId, $event->userId);
+        $this->assertEquals($user->deviceId, $event->deviceId);
+        $this->assertEquals('[Experiment] Assignment', $event->eventType);
+
+        $eventProperties = $event->eventProperties;
+        $this->assertEquals('control', $eventProperties['basic.variant']);
+        $this->assertEquals('v10 rule:All Other Users', $eventProperties['basic.details']);
+        $this->assertEquals('on', $eventProperties['different_value.variant']);
+        $this->assertEquals('v10 rule:All Other Users', $eventProperties['different_value.details']);
+        $this->assertEquals('off', $eventProperties['default.variant']);
+        $this->assertEquals('v10 rule:All Other Users', $eventProperties['default.details']);
+        $this->assertEquals('slot-1', $eventProperties['mutex.variant']);
+        $this->assertEquals('v10 rule:All Other Users', $eventProperties['mutex.details']);
+        $this->assertEquals('holdout', $eventProperties['holdout.variant']);
+        $this->assertEquals('v10 rule:All Other Users', $eventProperties['holdout.details']);
+        $this->assertEquals('on', $eventProperties['partial_metadata.variant']);
+        $this->assertEquals('on', $eventProperties['empty_metadata.variant']);
+
+        $userProperties = $event->userProperties;
+        $setProperties = $userProperties['$set'];
+        $this->assertEquals('control', $setProperties['[Experiment] basic']);
+        $this->assertEquals('on', $setProperties['[Experiment] different_value']);
+        $this->assertEquals('holdout', $setProperties['[Experiment] holdout']);
+        $this->assertEquals('on', $setProperties['[Experiment] partial_metadata']);
+        $this->assertEquals('on', $setProperties['[Experiment] empty_metadata']);
+        $unsetProperties = $userProperties['$unset'];
+        $this->assertEquals('-', $unsetProperties['[Experiment] default']);
+
+        $canonicalization = 'user device basic control default off different_value on empty_metadata on holdout holdout mutex slot-1 partial_metadata on ';
+        $expected = "user device " . hashCode($canonicalization) . ' ' . floor($assignment->timestamp / DAY_MILLIS);
+        $this->assertEquals($expected, $event->insertId);
+
+        $expectedPayload = json_encode(["api_key" => 'apiKey', "events" => [$event], "options" => ["min_id_length" => 10]]);
+        $this->assertEquals($expectedPayload, $assignment->toJSONPayload());
+    }
+}


### PR DESCRIPTION
**Summary**

- [AssignmentTrackingProvider](https://github.com/amplitude/experiment-php-server/pull/14/files#diff-602ed8a2c0d6eb69ffb6310151a23f970e7b12e3428fac28f997f2d99d9fb6e6) interface
    - Implementation needs to be passed to `AssignmentConfig` to send assignment events from local evaluations to Amplitude
    - The `track` method takes in an Assignment object, which represents an [assignment event](https://www.docs.developers.amplitude.com/experiment/general/experiment-event-tracking/#assignment-events)
    - Sending an event to Amplitude
        - see [developer docs](https://www.docs.developers.amplitude.com/analytics/apis/batch-event-upload-api/) for more details
        - `Assignment::toJSONPayload` can be used to convert an Assignment to a JSON string representation of the [payload](https://www.docs.developers.amplitude.com/analytics/apis/batch-event-upload-api/#parameters) required to send an event to Amplitude
        - `Assignment::toJSONString` can be used to convert an Assignment to a JSON string representation of an assignment event - this is equivalent to an object in the `events` array in the payload

- [DefaultAssignmentTrackingProvider](https://github.com/amplitude/experiment-php-server/pull/14/files#diff-d7f173a613632e3081d4cce10eb380d03344d1ab9104e3928da26e2d9d9a3a0c)
    - A default implementation of the AssignmentTrackingProvider interface which uses the synchronous internal Amplitude package
    - Recommended for use of testing and applications where latency is less of a concern

- Refactors
    - `minIdLength` (minimum permitted length for `user_id` and `device_id` fields for assignment event) added to `AssignmentConfig`
    - Internal Amplitude package is no longer automatically used to send assignment events
    - `logger` added to `AmplitudeConfig` instead of being passed via `LocaEvaluationClient`
    - `toEvent` moved from `AssignmentService` to `Assignment`