### PR TITLE
fix: use explicit nullable type for AmplitudeConfig

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/src/Amplitude/Amplitude.php
+++ b/src/Amplitude/Amplitude.php
@@ -26,7 +26,7 @@ class Amplitude
     private LoggerInterface $logger;
     private AmplitudeConfig $config;
 
-    public function __construct(string $apiKey, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, ?AmplitudeConfig $config = null)
     {
         $this->apiKey = $apiKey;
         $this->config = $config ?? AmplitudeConfig::builder()->build();

--- a/tests/Amplitude/MockAmplitude.php
+++ b/tests/Amplitude/MockAmplitude.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 
 class MockAmplitude extends Amplitude
 {
-    public function __construct(string $apiKey, AmplitudeConfig $config = null)
+    public function __construct(string $apiKey, ?AmplitudeConfig $config = null)
     {
         parent::__construct($apiKey, $config);
     }


### PR DESCRIPTION
This fixes the following error:

> PHP Deprecated:  AmplitudeExperiment\Amplitude\Amplitude::__construct(): Implicitly marking parameter $config as nullable is deprecated, the explicit nullable type must be used instead
