### PR TITLE
Fix handling of booleans in conditions

### DIFF
--- a/src/EvaluationCore/EvaluationEngine.php
+++ b/src/EvaluationCore/EvaluationEngine.php
@@ -248,16 +248,16 @@ class EvaluationEngine
 
     private function matchesIs(string $propValue, array $filterValues): bool
     {
-        if ($this->containsBooleans($filterValues)) {
-            $lower = strtolower($propValue);
-            if ($lower === 'true' || $lower === 'false') {
-                foreach ($filterValues as $value) {
-                    if (strtolower($value) === $lower) {
-                        return true;
-                    }
-                }
-            }
+        $lowerFilterValues = array_map('strtolower', $filterValues);
+        $lowerPropValue = strtolower($propValue);
+        if (in_array('true', $lowerFilterValues) && in_array($lowerPropValue, ['true', '1'])) {
+            return true;
         }
+
+        if (in_array('false', $lowerFilterValues) && in_array($lowerPropValue, ['false', '0'])) {
+            return true;
+        }
+
         return in_array($propValue, $filterValues);
     }
 
@@ -348,17 +348,6 @@ class EvaluationEngine
     private function containsNone(array $filterValues): bool
     {
         return in_array('(none)', $filterValues);
-    }
-
-    private function containsBooleans(array $filterValues): bool
-    {
-        foreach ($filterValues as $filterValue) {
-            $lowercaseFilterValue = strtolower($filterValue);
-            if ($lowercaseFilterValue === 'true' || $lowercaseFilterValue === 'false') {
-                return true;
-            }
-        }
-        return false;
     }
 
     private function parseNumber(string $value): ?int

--- a/tests/EvaluationCore/EvaluationEngineTest.php
+++ b/tests/EvaluationCore/EvaluationEngineTest.php
@@ -26,8 +26,12 @@ final class EvaluationEngineTest extends TestCase
         yield ['True', ['true']];
         yield ['True', ['True']];
 
+        yield [true, ['true']];
+        yield [true, ['True']];
         yield [true, ['1']];
 
+        yield ['1', ['true']];
+        yield ['1', ['True']];
         yield ['1', ['1']];
 
         yield ['false', ['false']];
@@ -36,6 +40,8 @@ final class EvaluationEngineTest extends TestCase
         yield ['False', ['false']];
         yield ['False', ['False']];
 
+        yield ['0', ['false']];
+        yield ['0', ['False']];
         yield ['0', ['0']];
     }
 

--- a/tests/EvaluationCore/EvaluationEngineTest.php
+++ b/tests/EvaluationCore/EvaluationEngineTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AmplitudeExperiment\Test\EvaluationCore;
+
+use AmplitudeExperiment\EvaluationCore\EvaluationEngine;
+use PHPUnit\Framework\TestCase;
+
+final class EvaluationEngineTest extends TestCase
+{
+    private EvaluationEngine $evaluation;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->evaluation = new EvaluationEngine();
+    }
+
+    public function booleanValues() : iterable
+    {
+        yield ['true', ['true']];
+        yield ['true', ['True']];
+
+        yield ['True', ['true']];
+        yield ['True', ['True']];
+
+        yield [true, ['1']];
+
+        yield ['1', ['1']];
+
+        yield ['false', ['false']];
+        yield ['false', ['False']];
+
+        yield ['False', ['false']];
+        yield ['False', ['False']];
+
+        yield ['0', ['0']];
+    }
+
+    /**
+     * @dataProvider booleanValues
+     */
+    public function testBooleans($propValue, array $filterValues) : void
+    {
+        self::assertSame(
+            [
+                'feature1' => [
+                    'key' => 'on',
+                    'value' => 'on',
+                    'metadata' => [
+                        'segmentName' => 'Employee only'
+                    ],
+                ],
+            ],
+            $this->evaluation->evaluate([
+                'user' => [
+                    'user_properties' => [
+                        'isEmployee' => $propValue,
+                    ],
+                ],
+            ], [
+                [
+                    'key' => 'feature1',
+                    'metadata' => [],
+                    'segments' => [
+                        [
+                            'conditions' => [
+                                [
+                                    [
+                                        'op' => 'is',
+                                        'selector' => ['context', 'user', 'user_properties', 'isEmployee'],
+                                        'values' => $filterValues,
+                                    ],
+                                ],
+                            ],
+                            'metadata' => [
+                                'segmentName' => 'Employee only',
+                            ],
+                            'variant' => 'on',
+                        ],
+                        [
+                            'metadata' => [
+                                'segmentName' => 'All Other Users',
+                            ],
+                            'variant' => 'off',
+                        ],
+                    ],
+                    'variants' =>
+                        [
+                            'off' => [
+                                'key' => 'off',
+                                'metadata' => [
+                                    'default' => true,
+                                ],
+                            ],
+                            'on' => [
+                                'key' => 'on',
+                                'value' => 'on',
+                            ],
+                        ],
+                ],
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
Booleans are currently handled very poorly.

Especially when the context contains real `true` or `false` booleans.

The Amplitude UI often shows `True` and `False` as auto completions.

Since this SDK uses `strval` to convert a boolean to a string value, a boolean `true` becomes string `1`. And boolean `false` becomes string `0`.

But if the flag's condition uses string `True` or `False`, it won't match.

To solve this, we add more test cases, and refactor the `matchesIs` in the EvaluationEngine.

I also tried to add the following test cases:
```
        yield [false, ['false']];
        yield [false, ['False']];
        yield [false, ['0']];
```

But these fail because they are intercepted and handled as nullables:
https://github.com/amplitude/experiment-php-server/blob/35278483b2e815ab3fef50636af9d2d3c94dc490/src/EvaluationCore/EvaluationEngine.php#L84-L89

While inspecting the code responsible for that, I really think this Evaluation Engine shouldn't have been made loosely typed but strictly typed instead 🤯 