### PR TITLE
feat(evaluation): multi-value array property support for non-set operators

### DIFF
--- a/src/EvaluationCore/EvaluationEngine.php
+++ b/src/EvaluationCore/EvaluationEngine.php
@@ -6,7 +6,6 @@ use AmplitudeExperiment\EvaluationCore\Types\EvaluationFlag;
 use AmplitudeExperiment\EvaluationCore\Types\EvaluationVariant;
 use AmplitudeExperiment\EvaluationCore\Types\EvaluationSegment;
 use AmplitudeExperiment\EvaluationCore\Types\EvaluationCondition;
-use Exception;
 
 class EvaluationEngine
 {
@@ -452,22 +451,28 @@ class EvaluationEngine
     private function coerceStringArray($value): ?array
     {
         if (is_array($value)) {
-            return array_filter(array_map([$this, 'coerceString'], $value));
+            return $this->filterNonNullStrings(array_map([$this, 'coerceString'], $value));
         }
         $stringValue = strval($value);
         if (strncmp($stringValue, '[', 1) !== 0) {
             return null;
         }
-        try {
-            $parsedValue = json_decode($stringValue, true);
-            if (is_array($parsedValue)) {
-                return array_filter(array_map([$this, 'coerceString'], $parsedValue));
-            } else {
-                return null;
-            }
-        } catch (Exception $e) {
+        $parsedValue = json_decode($stringValue, true);
+        if (!is_array($parsedValue)) {
             return null;
         }
+        return $this->filterNonNullStrings(array_map([$this, 'coerceString'], $parsedValue));
+    }
+
+    /**
+     * @param array<mixed> $values
+     * @return array<string>
+     */
+    private function filterNonNullStrings(array $values): array
+    {
+        return array_values(array_filter($values, function ($v) {
+            return $v !== null;
+        }));
     }
 
     private function isSetOperator(string $op): bool

--- a/src/EvaluationCore/EvaluationEngine.php
+++ b/src/EvaluationCore/EvaluationEngine.php
@@ -117,29 +117,30 @@ class EvaluationEngine
 
         if ($propValue === null) {
             return $this->matchNull($condition->op, $condition->values);
-        } elseif (is_bool($propValue)) {
-            return $this->matchBoolean($propValue, $condition->op, $condition->values);
-        } elseif ($this->isSetOperator($condition->op)) {
-            $propValueStringList = $this->coerceStringArray($propValue);
+        }
 
+        if (is_bool($propValue)) {
+            return $this->matchBoolean($propValue, $condition->op, $condition->values);
+        }
+
+        $propValueStringList = $this->coerceStringArray($propValue);
+
+        if ($this->isSetOperator($condition->op)) {
             if ($propValueStringList === null) {
                 return false;
             }
-
             return $this->matchSet($propValueStringList, $condition->op, $condition->values);
-        } else {
-            $propValueString = $this->coerceString($propValue);
-
-            if ($propValueString !== null) {
-                return $this->matchString(
-                    $propValueString,
-                    $condition->op,
-                    $condition->values
-                );
-            } else {
-                return false;
-            }
         }
+
+        if ($propValueStringList !== null) {
+            return $this->matchStringsNonSet($propValueStringList, $condition->op, $condition->values);
+        }
+
+        $propValueString = $this->coerceString($propValue);
+        if ($propValueString === null) {
+            return false;
+        }
+        return $this->matchString($propValueString, $condition->op, $condition->values);
     }
 
     /**
@@ -301,6 +302,22 @@ class EvaluationEngine
     }
 
     /**
+     * @param array<string> $propValues
+     * @param string $op
+     * @param array<string> $filterValues
+     * @return bool
+     */
+    private function matchStringsNonSet(array $propValues, string $op, array $filterValues): bool
+    {
+        foreach ($propValues as $propValue) {
+            if ($this->matchString($propValue, $op, $filterValues)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param string $propValue
      * @param array<string> $filterValues
      * @return bool
@@ -438,6 +455,9 @@ class EvaluationEngine
             return array_filter(array_map([$this, 'coerceString'], $value));
         }
         $stringValue = strval($value);
+        if (strncmp($stringValue, '[', 1) !== 0) {
+            return null;
+        }
         try {
             $parsedValue = json_decode($stringValue, true);
             if (is_array($parsedValue)) {

--- a/tests/EvaluationCore/EvaluateIntegrationTest.php
+++ b/tests/EvaluationCore/EvaluateIntegrationTest.php
@@ -570,6 +570,69 @@ class EvaluateIntegrationTest extends TestCase
         $this->assertEquals('on', $variant->key);
     }
 
+    public function testSetIsWithJsonArrayString()
+    {
+        $user = $this->userContext(null, null, null, ['key' => '["1", "2", "3"]']);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-set-is'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testIsWithArray()
+    {
+        $user = $this->userContext(null, null, null, ['key' => ['value1', 'value2']]);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-is-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testIsNotWithArray()
+    {
+        $user = $this->userContext(null, null, null, ['key' => ['value3', 'value4']]);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-is-not-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testContainsWithArray()
+    {
+        $user = $this->userContext(null, null, null, ['key' => ['has-target-value', 'has', 'value']]);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-contains-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testDoesNotContainWithArray()
+    {
+        $user = $this->userContext(null, null, null, ['key' => ['has-value', 'has', 'value']]);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-does-not-contain-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testIsWithJsonArrayString()
+    {
+        $user = $this->userContext(null, null, null, ['key' => '["value1", "value2"]']);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-is-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
+    public function testDoesNotContainWithJsonArrayString()
+    {
+        $user = $this->userContext(null, null, null, ['key' => '["has-value", "has", "value"]']);
+        $results = $this->engine->evaluate($user, $this->flags);
+        $result = $results['test-does-not-contain-array'];
+        $variant = Variant::convertEvaluationVariantToVariant($result);
+        $this->assertEquals('on', $variant->key);
+    }
+
     public function testGlobMatch()
     {
         $user = $this->userContext(null, null, null, ['key' => '/path/1/2/3/end']);

--- a/tests/EvaluationCore/EvaluateIntegrationTest.php
+++ b/tests/EvaluationCore/EvaluateIntegrationTest.php
@@ -26,7 +26,7 @@ class EvaluateIntegrationTest extends TestCase
     protected function setUp(): void
     {
         $this->engine = new EvaluationEngine();
-        $rawFlags = $this->getFlags('server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy');
+        $rawFlags = $this->getFlags('server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh');
         $this->flags = createFlagsFromArray($rawFlags);
     }
 

--- a/tests/EvaluationCore/EvaluationEngineTest.php
+++ b/tests/EvaluationCore/EvaluationEngineTest.php
@@ -253,4 +253,45 @@ class EvaluationEngineTest extends TestCase
         $this->assertEquals('off', $results['test-case-bool']->key,
             "Non-boolean value should match default segment");
     }
+
+    private function flagWithCondition(string $op, array $values): EvaluationFlag
+    {
+        $variants = ['on' => new EvaluationVariant('on')];
+        $segment = new EvaluationSegment(
+            null,
+            [[new EvaluationCondition(
+                ['context', 'user', 'user_properties', 'test_prop'],
+                $op,
+                $values
+            )]],
+            'on'
+        );
+        return new EvaluationFlag('test-flag', $variants, [$segment]);
+    }
+
+    private function contextWithProp($value): array
+    {
+        return ['user' => ['user_properties' => ['test_prop' => $value]]];
+    }
+
+    private function evaluateProp($propValue, string $op, array $values): ?EvaluationVariant
+    {
+        $flag = $this->flagWithCondition($op, $values);
+        $context = $this->contextWithProp($propValue);
+        $results = $this->engine->evaluate($context, ['test-flag' => $flag]);
+        return $results['test-flag'] ?? null;
+    }
+
+    private function assertMatch($propValue, string $op, array $values): void
+    {
+        $result = $this->evaluateProp($propValue, $op, $values);
+        $this->assertNotNull($result, "Expected match, got null");
+        $this->assertEquals('on', $result->key);
+    }
+
+    private function assertNoMatch($propValue, string $op, array $values): void
+    {
+        $result = $this->evaluateProp($propValue, $op, $values);
+        $this->assertNull($result, "Expected no match, got variant");
+    }
 }

--- a/tests/EvaluationCore/EvaluationEngineTest.php
+++ b/tests/EvaluationCore/EvaluationEngineTest.php
@@ -254,6 +254,41 @@ class EvaluationEngineTest extends TestCase
             "Non-boolean value should match default segment");
     }
 
+    public function testMultiValueArrayPropertyMatching()
+    {
+        // Scalar string cases (regression coverage)
+        $this->assertMatch('hello', 'is', ['hello']);
+        $this->assertMatch('hello', 'contains', ['ell']);
+        $this->assertMatch('2', 'greater', ['1']);
+        $this->assertNoMatch('world', 'is', ['hello']);
+
+        // Non-string scalar cases
+        $this->assertMatch(42, 'greater', ['1']);
+        $this->assertMatch(true, 'is', ['true']);
+
+        // JSON array string + set operator
+        $this->assertMatch('["a","b"]', 'set contains', ['a']);
+
+        // JSON array string + non-set operator (NEW behavior)
+        $this->assertMatch('["a","b"]', 'is', ['a']);
+
+        // Collection + set operator
+        $this->assertMatch(['a', 'b'], 'set contains', ['a']);
+
+        // Collection + non-set operator (NEW behavior)
+        $this->assertMatch(['a', 'b'], 'is', ['a']);
+
+        // Malformed JSON array -- falls through to scalar matchString
+        $this->assertMatch('[broken', 'is', ['[broken']);
+
+        // Empty JSON array + set operator
+        $this->assertNoMatch('[]', 'set contains', ['a']);
+
+        // Leading whitespace prevents array parsing -- treated as scalar
+        $this->assertMatch(' ["a"]', 'is', [' ["a"]']);
+        $this->assertNoMatch(' ["a"]', 'set contains', ['a']);
+    }
+
     private function flagWithCondition(string $op, array $values): EvaluationFlag
     {
         $variants = ['on' => new EvaluationVariant('on')];

--- a/tests/EvaluationCore/EvaluationEngineTest.php
+++ b/tests/EvaluationCore/EvaluationEngineTest.php
@@ -287,6 +287,10 @@ class EvaluationEngineTest extends TestCase
         // Leading whitespace prevents array parsing -- treated as scalar
         $this->assertMatch(' ["a"]', 'is', [' ["a"]']);
         $this->assertNoMatch(' ["a"]', 'set contains', ['a']);
+
+        // Falsy string elements ("0", "") are preserved (only nulls are dropped)
+        $this->assertMatch(['0', 'a'], 'is', ['0']);
+        $this->assertMatch(['', 'a'], 'is', ['']);
     }
 
     private function flagWithCondition(string $op, array $values): EvaluationFlag


### PR DESCRIPTION
## Summary

Non-set operators (`is`, `is not`, `contains`, `does not contain`, `greater`, `less`, regex, version) now match array-valued user properties element-wise, returning true if **any** element satisfies the predicate. Previously, array values were stringified via `coerceString` and compared as a single blob, diverging from Amplitude analytics/charts behavior.

Applies to both native PHP arrays and JSON-array-string properties (e.g. `'["a","b"]'`). Set operators retain their existing semantics. Boolean short-circuit and scalar-string paths are unchanged.

## Changes

- `matchCondition` restructured so `coerceStringArray` is called for every non-null, non-boolean value. New `matchStringsNonSet` helper delegates to `matchString` per element.
- `coerceStringArray` gains a `[`-prefix pre-check (via `strncmp`, PHP 7.4-safe) so scalar strings short-circuit before `json_decode`.
- `coerceStringArray` now correctly preserves `"0"` and `""` elements — it used to drop them via default `array_filter` truthiness, which contradicted the spec's "filter nulls only" contract.
- Unreachable `try/catch` around `json_decode` removed (PHP returns `null` on parse failure; the existing `is_array` check already handles it).

## Tests

- Unit test harness + 16 cases in `EvaluationEngineTest::testMultiValueArrayPropertyMatching` covering scalars, JSON-array strings, PHP collections, malformed JSON, empty arrays, leading-whitespace strings, and falsy-string elements across both set and non-set operators.
- 7 new integration tests in `EvaluateIntegrationTest` exercising the array-property flags on the shared evaluation deployment.
- Integration deployment key consolidated to a single superset key per the cross-SDK spec.
- Full suite: 154 tests / 2522 assertions passing; phpstan clean.

## Test plan

- [ ] `./vendor/bin/phpunit --no-coverage`
- [ ] `./vendor/bin/phpstan analyse`
- [ ] Spot-check: flag with `is` operator against a user property set to a PHP array — should now match any element (previously required `set` operator or JSON-array string contortions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag targeting semantics: non-set operators now evaluate array/JSON-array user properties element-wise, which can alter rollout/segment matches for existing flags. Risk is mitigated by added unit/integration coverage but still impacts evaluation behavior broadly.
> 
> **Overview**
> **Adds multi-value property matching for non-set operators.** `matchCondition` now attempts to coerce non-null, non-boolean properties into string arrays and, for non-set operators (e.g. `is`, `contains`, comparisons, regex, version), returns true if *any* element matches via a new `matchStringsNonSet` helper; set operators keep existing semantics.
> 
> **Tightens array coercion behavior.** `coerceStringArray` now fast-paths non-array strings that don’t start with `[` before attempting `json_decode`, removes the unused `try/catch`, and filters out only `null` elements (preserving falsy strings like `"0"`/`""`) via `filterNonNullStrings`.
> 
> **Updates tests.** Adds comprehensive unit coverage for scalar/array/JSON-array cases and edge conditions, and extends integration tests for array/JSON-array targeting; also updates the integration deployment key used to fetch test flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2045fa9037d3e572a2cc37190c025d8033964f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->