### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/src/Exposure/Exposure.php
+++ b/src/Exposure/Exposure.php
@@ -93,6 +93,10 @@ class Exposure
             } elseif ($variant->value) {
                 $event->eventProperties['[Experiment] Variant'] = $variant->value;
             }
+            $experimentKey = $variant->metadata['experimentKey'] ?? null;
+            if ($experimentKey) {
+                $event->eventProperties['[Experiment] Experiment Key'] = $experimentKey;
+            }
             if ($variant->metadata) {
                 $event->eventProperties['metadata'] = $variant->metadata;
             }

--- a/tests/Exposure/ExposureServiceTest.php
+++ b/tests/Exposure/ExposureServiceTest.php
@@ -69,6 +69,13 @@ class ExposureServiceTest extends TestCase
         ]);
         $emptyMetadata = new Variant('on', 'on');
         $emptyVariant = new Variant();
+        $withExperimentKey = new Variant('treatment', 'treatment', null, null, [
+            'segmentName' => 'All Other Users',
+            'flagType' => 'experiment',
+            'flagVersion' => 10,
+            'default' => false,
+            'experimentKey' => 'exp-1'
+        ]);
         $results = [
             'basic' => $basic,
             'different_value' => $differentValue,
@@ -77,23 +84,24 @@ class ExposureServiceTest extends TestCase
             'holdout' => $holdout,
             'partial_metadata' => $partialMetadata,
             'empty_metadata' => $emptyMetadata,
-            'empty_variant' => $emptyVariant
+            'empty_variant' => $emptyVariant,
+            'with_experiment_key' => $withExperimentKey
         ];
         $exposure = new Exposure($user, $results);
         $events = $exposure->toEvents();
         // Should exclude default (default=true) only
-        // basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant = 7 events
-        $this->assertCount(7, $events);
-        
+        // basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant, with_experiment_key = 8 events
+        $this->assertCount(8, $events);
+
         foreach ($events as $event) {
             $this->assertEquals('[Experiment] Exposure', $event->eventType);
             $this->assertEquals($user->userId, $event->userId);
             $this->assertEquals($user->deviceId, $event->deviceId);
-            
+
             $flagKey = $event->eventProperties['[Experiment] Flag Key'];
             $this->assertArrayHasKey($flagKey, $results);
             $variant = $results[$flagKey];
-            
+
             // Validate event properties
             if ($variant->key) {
                 $this->assertEquals($variant->key, $event->eventProperties['[Experiment] Variant']);
@@ -102,6 +110,12 @@ class ExposureServiceTest extends TestCase
             }
             if ($variant->metadata) {
                 $this->assertEquals($variant->metadata, $event->eventProperties['metadata']);
+            }
+
+            if ($flagKey === 'with_experiment_key') {
+                $this->assertEquals('exp-1', $event->eventProperties['[Experiment] Experiment Key']);
+            } else {
+                $this->assertArrayNotHasKey('[Experiment] Experiment Key', $event->eventProperties);
             }
             
             // Validate user properties


### PR DESCRIPTION
## Summary

- Local evaluation exposure events from `Exposure::toEvents()` carried `experimentKey` only inside the `metadata` blob — the top-level event property `[Experiment] Experiment Key` was never set, so custom reports keying off it saw no value for local-eval customers.
- Fix: when `variant->metadata['experimentKey']` is truthy, set `event->eventProperties['[Experiment] Experiment Key']`. Additive and backwards-compatible — `metadata`, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `insertId` are unchanged.
- Mirrors [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `with_experiment_key` fixture to `ExposureServiceTest::testToEventsCreatesOneEventPerFlag`. Asserts `[Experiment] Experiment Key` equals `'exp-1'` for that flag and is absent for the others.
- [x] Updated event count expectation accordingly.
- [x] `vendor/bin/phpunit tests/Exposure/ExposureServiceTest.php` — 2 tests, 70 assertions, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive event-property change gated on existing `metadata['experimentKey']`, with a focused unit test update.
> 
> **Overview**
> Local-eval `Exposure::toEvents()` now copies `variant->metadata['experimentKey']` onto a top-level event property, `"[Experiment] Experiment Key"`, when present (while still including the full `metadata` blob).
> 
> Tests extend `ExposureServiceTest::testToEventsCreatesOneEventPerFlag` with a new `with_experiment_key` fixture, update the expected event count, and assert the property is set only for that flag and absent otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79da2e912f1233f020119c19155e96ee4b61367b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->